### PR TITLE
Implement filesystem storage consistency checks on startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ Cargo.lock
 # OpenCode
 .opencode/config.json
 .opencode/auth.json
+entities.json
+
+mempalace.yaml

--- a/api/src/startup.rs
+++ b/api/src/startup.rs
@@ -4,6 +4,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use chrono::Local;
 use tokio::signal;
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -49,16 +50,18 @@ pub async fn init_app_state(config: Config) -> Result<AppState, String> {
     }
     let _ = tokio::fs::remove_file(&test_file).await;
 
+    let boot_ts = Local::now().format("%Y%m%d_%H%M%S").to_string();
+
     let task_store: Arc<dyn TaskStore> =
-        Arc::new(FileSystemTaskStore::new(storage_path.clone()).await);
+        Arc::new(FileSystemTaskStore::new_with_boot_ts(storage_path.clone(), boot_ts.clone()).await);
     tracing::info!("Initialized filesystem task store");
 
     let photo_store: Arc<dyn PhotoStore> =
-        Arc::new(FileSystemPhotoStore::new(storage_path.clone(), task_store.clone()).await);
+        Arc::new(FileSystemPhotoStore::new_with_boot_ts(storage_path.clone(), task_store.clone(), boot_ts.clone()).await);
     tracing::info!("Initialized filesystem photo store");
 
     let job_store: Arc<dyn JobStore> =
-        Arc::new(FileSystemJobStore::new(storage_path, task_store.clone()).await);
+        Arc::new(FileSystemJobStore::new_with_boot_ts(storage_path, task_store.clone(), boot_ts).await);
     tracing::info!("Initialized filesystem job store");
 
     // Initialize AI provider registry

--- a/api/src/storage/filesystem_job_store.rs
+++ b/api/src/storage/filesystem_job_store.rs
@@ -20,9 +20,11 @@ use crate::models::Job;
 use super::utils::parse_uuid_from_dir;
 use super::{FileSystemLayout, JobStore, JobStoreError, JobStoreResult, TaskStore};
 
-// ============================================================================
-// FileSystemJobStore Implementation
-// ============================================================================
+fn sorted_jobs(iter: impl Iterator<Item = Job>) -> Vec<Job> {
+    let mut jobs: Vec<Job> = iter.collect();
+    jobs.sort_by_key(|j| j.created_at);
+    jobs
+}
 
 /// Filesystem-backed implementation of JobStore with full persistence.
 ///
@@ -48,7 +50,6 @@ use super::{FileSystemLayout, JobStore, JobStoreError, JobStoreResult, TaskStore
 pub struct FileSystemJobStore {
     jobs: Arc<DashMap<Uuid, Job>>,
     layout: FileSystemLayout,
-    /// Reference to the task store for resolving catalog identity
     task_store: Arc<dyn TaskStore>,
 }
 
@@ -202,10 +203,6 @@ impl FileSystemJobStore {
     }
 }
 
-// ============================================================================
-// JobStore Trait Implementation
-// ============================================================================
-
 #[async_trait]
 impl JobStore for FileSystemJobStore {
     async fn create(&self, job: Job) -> JobStoreResult<Job> {
@@ -215,7 +212,6 @@ impl JobStore for FileSystemJobStore {
 
         let catalog_id = self.resolve_catalog_id(job.task_id).await?;
 
-        // Use entry API to atomically check and insert
         match self.jobs.entry(job_id) {
             Entry::Occupied(_) => Err(JobStoreError::AlreadyExists(job_id)),
             Entry::Vacant(entry) => {
@@ -232,7 +228,6 @@ impl JobStore for FileSystemJobStore {
                     })?;
                 debug!("Ensured jobs directory exists: {:?}", job_dir);
 
-                // Save metadata to filesystem
                 self.save_job_to_file(&job, catalog_id).await?;
 
                 entry.insert(job.clone());
@@ -251,22 +246,13 @@ impl JobStore for FileSystemJobStore {
     async fn get(&self, job_id: Uuid) -> JobStoreResult<Option<Job>> {
         debug!("Retrieving job: {}", job_id);
 
-        // Lock-free read with DashMap
         Ok(self.jobs.get(&job_id).map(|entry| entry.value().clone()))
     }
 
     async fn list(&self) -> JobStoreResult<Vec<Job>> {
         debug!("Listing all jobs");
 
-        // Collect all jobs into a vector
-        let mut jobs: Vec<Job> = self
-            .jobs
-            .iter()
-            .map(|entry| entry.value().clone())
-            .collect();
-
-        // Sort by created_at (oldest first) for deterministic output
-        jobs.sort_by_key(|job| job.created_at);
+        let jobs = sorted_jobs(self.jobs.iter().map(|e| e.value().clone()));
 
         info!("Listed {} jobs", jobs.len());
         Ok(jobs)
@@ -275,15 +261,12 @@ impl JobStore for FileSystemJobStore {
     async fn list_by_task(&self, task_id: Uuid) -> JobStoreResult<Vec<Job>> {
         debug!("Listing jobs for task: {}", task_id);
 
-        let mut jobs: Vec<Job> = self
-            .jobs
-            .iter()
-            .filter(|entry| entry.value().task_id == task_id)
-            .map(|entry| entry.value().clone())
-            .collect();
-
-        // Sort by created_at (oldest first) for deterministic output
-        jobs.sort_by_key(|job| job.created_at);
+        let jobs = sorted_jobs(
+            self.jobs
+                .iter()
+                .filter(|e| e.value().task_id == task_id)
+                .map(|e| e.value().clone()),
+        );
 
         info!("Listed {} jobs for task {}", jobs.len(), task_id);
         Ok(jobs)
@@ -330,8 +313,10 @@ impl JobStore for FileSystemJobStore {
         let job_path = self
             .layout
             .job_file_path(catalog_id, job.task_id, job.job_id);
-        if job_path.exists() {
-            if let Err(e) = tokio::fs::remove_file(&job_path).await {
+        match tokio::fs::remove_file(&job_path).await {
+            Ok(()) => debug!("Removed job file: {:?}", job_path),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
                 error!("Failed to remove job file {:?}: {}", job_path, e);
                 self.jobs.insert(job_id, job);
                 return Err(JobStoreError::StorageError(format!(
@@ -339,7 +324,6 @@ impl JobStore for FileSystemJobStore {
                     e
                 )));
             }
-            debug!("Removed job file: {:?}", job_path);
         }
 
         info!(
@@ -352,7 +336,6 @@ impl JobStore for FileSystemJobStore {
     async fn delete_by_task(&self, task_id: Uuid) -> JobStoreResult<usize> {
         debug!("Deleting all jobs for task: {}", task_id);
 
-        // Collect job_ids to delete (can't delete while iterating)
         let job_ids: Vec<Uuid> = self
             .jobs
             .iter()
@@ -367,18 +350,15 @@ impl JobStore for FileSystemJobStore {
 
         let catalog_id = self.resolve_catalog_id(task_id).await?;
 
-        // Remove all jobs and their files
         for job_id in job_ids {
             if let Some((_, job)) = self.jobs.remove(&job_id) {
                 let job_path = self
                     .layout
                     .job_file_path(catalog_id, job.task_id, job.job_id);
-                if job_path.exists() {
-                    if let Err(e) = tokio::fs::remove_file(&job_path).await {
-                        error!("Failed to remove job file {:?}: {}", job_path, e);
-                    } else {
-                        debug!("Removed job file: {:?}", job_path);
-                    }
+                match tokio::fs::remove_file(&job_path).await {
+                    Ok(()) => debug!("Removed job file: {:?}", job_path),
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(e) => error!("Failed to remove job file {:?}: {}", job_path, e),
                 }
             }
         }
@@ -390,7 +370,6 @@ impl JobStore for FileSystemJobStore {
     async fn exists(&self, job_id: Uuid) -> JobStoreResult<bool> {
         debug!("Checking if job exists: {}", job_id);
 
-        // Lock-free existence check
         Ok(self.jobs.contains_key(&job_id))
     }
 
@@ -407,10 +386,6 @@ impl JobStore for FileSystemJobStore {
     }
 }
 
-// ============================================================================
-// Unit Tests
-// ============================================================================
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -420,14 +395,12 @@ mod tests {
     use tempfile::TempDir;
     use uuid::Uuid;
 
-    // Helper struct to keep temp dir alive during test
     struct TestStore {
         store: FileSystemJobStore,
         task_store: Arc<dyn TaskStore>,
         _temp_dir: TempDir,
     }
 
-    // Helper function to create a fresh store with temp directory
     async fn create_store() -> TestStore {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let storage_path = temp_dir.path().to_path_buf();
@@ -456,12 +429,11 @@ mod tests {
         catalog_id
     }
 
-    // Helper function to create a test job
+
     fn create_test_job(task_id: Uuid, model: &str, photo_ids: Vec<Uuid>) -> Job {
         Job::new(task_id, model.to_string(), None, photo_ids)
     }
 
-    // Helper function to create a test job with specific timestamp
     fn create_test_job_with_timestamp(
         task_id: Uuid,
         model: &str,
@@ -469,7 +441,6 @@ mod tests {
         timestamp: DateTime<Utc>,
     ) -> Job {
         let job = Job::new(task_id, model.to_string(), None, photo_ids);
-        // Use a hack to set the timestamp via serialization
         let mut job_value = serde_json::to_value(&job).unwrap();
         job_value["created_at"] = serde_json::to_value(timestamp).unwrap();
         serde_json::from_value(job_value).unwrap()
@@ -492,14 +463,11 @@ mod tests {
         assert_eq!(created.model, job.model);
         assert_eq!(created.status, JobStatus::Queued);
 
-        // Verify it exists in the store
         let exists = ts.store.exists(job.job_id).await.unwrap();
         assert!(exists);
 
-        // Verify jobs directory was created
         assert!(ts.store.layout.jobs_dir(catalog_id, task_id).exists());
 
-        // Verify job JSON file was created
         assert!(
             ts.store
                 .layout
@@ -516,10 +484,8 @@ mod tests {
         let photo_ids = vec![Uuid::new_v4()];
         let job = create_test_job(task_id, "qwen3-vl:8b", photo_ids);
 
-        // First creation should succeed
         ts.store.create(job.clone()).await.unwrap();
 
-        // Second creation with same ID should fail
         let result = ts.store.create(job.clone()).await;
 
         assert!(result.is_err());
@@ -566,7 +532,6 @@ mod tests {
         let task_id = Uuid::new_v4();
         setup_task(&ts, task_id).await;
 
-        // Create jobs with explicit timestamps to control ordering
         let now = Utc::now();
         let job1 =
             create_test_job_with_timestamp(task_id, "qwen3-vl:8b", vec![Uuid::new_v4()], now);
@@ -583,12 +548,10 @@ mod tests {
             now + Duration::seconds(2),
         );
 
-        // Insert in random order
         ts.store.create(job2.clone()).await.unwrap();
         ts.store.create(job1.clone()).await.unwrap();
         ts.store.create(job3.clone()).await.unwrap();
 
-        // List should return ordered by created_at (oldest first)
         let jobs = ts.store.list().await.unwrap();
 
         assert_eq!(jobs.len(), 3);
@@ -601,7 +564,6 @@ mod tests {
     async fn test_list_by_task() {
         let ts = create_store().await;
 
-        // Create jobs for two different tasks
         let task_a = Uuid::new_v4();
         let task_b = Uuid::new_v4();
         let task_c = Uuid::new_v4();
@@ -616,17 +578,14 @@ mod tests {
         ts.store.create(job2).await.unwrap();
         ts.store.create(job3).await.unwrap();
 
-        // List jobs for task_a
         let jobs_a = ts.store.list_by_task(task_a).await.unwrap();
         assert_eq!(jobs_a.len(), 2);
         assert!(jobs_a.iter().all(|j| j.task_id == task_a));
 
-        // List jobs for task_b
         let jobs_b = ts.store.list_by_task(task_b).await.unwrap();
         assert_eq!(jobs_b.len(), 1);
         assert_eq!(jobs_b[0].task_id, task_b);
 
-        // List jobs for nonexistent task
         let jobs_c = ts.store.list_by_task(task_c).await.unwrap();
         assert!(jobs_c.is_empty());
     }
@@ -640,7 +599,6 @@ mod tests {
 
         ts.store.create(job.clone()).await.unwrap();
 
-        // Update the job status
         job.start();
         let result = ts.store.update(job.clone()).await;
 
@@ -649,7 +607,6 @@ mod tests {
         assert_eq!(updated.status, JobStatus::Processing);
         assert!(updated.started_at.is_some());
 
-        // Verify the change persisted
         let retrieved = ts.store.get(job.job_id).await.unwrap().unwrap();
         assert_eq!(retrieved.status, JobStatus::Processing);
     }
@@ -661,7 +618,6 @@ mod tests {
         setup_task(&ts, task_id).await;
         let job = create_test_job(task_id, "qwen3-vl:8b", vec![Uuid::new_v4()]);
 
-        // Try to update without creating first
         let result = ts.store.update(job.clone()).await;
 
         assert!(result.is_err());
@@ -687,16 +643,13 @@ mod tests {
             .job_file_path(catalog_id, job.task_id, job.job_id);
         assert!(job_path.exists());
 
-        // Delete the job
         let result = ts.store.delete(job.job_id).await;
 
         assert!(result.is_ok());
 
-        // Verify it no longer exists
         let retrieved = ts.store.get(job.job_id).await.unwrap();
         assert!(retrieved.is_none());
 
-        // Verify file was removed
         assert!(!job_path.exists());
     }
 
@@ -720,7 +673,6 @@ mod tests {
     async fn test_delete_by_task() {
         let ts = create_store().await;
 
-        // Create jobs for two different tasks
         let task_a = Uuid::new_v4();
         let task_b = Uuid::new_v4();
         let catalog_id_a = setup_task(&ts, task_a).await;
@@ -745,19 +697,15 @@ mod tests {
         assert!(job1_path.exists());
         assert!(job2_path.exists());
 
-        // Delete all jobs for task_a
         let deleted = ts.store.delete_by_task(task_a).await.unwrap();
         assert_eq!(deleted, 2);
 
-        // Verify task_a jobs are gone
         let jobs_a = ts.store.list_by_task(task_a).await.unwrap();
         assert!(jobs_a.is_empty());
 
-        // Verify files were removed
         assert!(!job1_path.exists());
         assert!(!job2_path.exists());
 
-        // Verify task_b job still exists
         let jobs_b = ts.store.list_by_task(task_b).await.unwrap();
         assert_eq!(jobs_b.len(), 1);
     }
@@ -766,7 +714,6 @@ mod tests {
     async fn test_delete_by_task_nonexistent_returns_zero() {
         let ts = create_store().await;
 
-        // No task created — delete_by_task should find no jobs and return Ok(0)
         let result = ts.store.delete_by_task(Uuid::new_v4()).await;
 
         assert!(result.is_ok());
@@ -780,18 +727,14 @@ mod tests {
         setup_task(&ts, task_id).await;
         let job = create_test_job(task_id, "qwen3-vl:8b", vec![Uuid::new_v4()]);
 
-        // Should not exist initially
         let exists = ts.store.exists(job.job_id).await.unwrap();
         assert!(!exists);
 
-        // Create the job
         ts.store.create(job.clone()).await.unwrap();
 
-        // Should exist now
         let exists = ts.store.exists(job.job_id).await.unwrap();
         assert!(exists);
 
-        // Random ID should not exist
         let exists = ts.store.exists(Uuid::new_v4()).await.unwrap();
         assert!(!exists);
     }
@@ -805,11 +748,9 @@ mod tests {
         setup_task(&ts, task_a).await;
         setup_task(&ts, task_b).await;
 
-        // Empty task should have count 0
         let count = ts.store.count_by_task(task_a).await.unwrap();
         assert_eq!(count, 0);
 
-        // Add jobs
         let photo_id = Uuid::new_v4();
         let job1 = create_test_job(task_a, "qwen3-vl:8b", vec![photo_id]);
         let job2 = create_test_job(task_a, "llava", vec![photo_id]);
@@ -819,11 +760,9 @@ mod tests {
         ts.store.create(job2).await.unwrap();
         ts.store.create(job3).await.unwrap();
 
-        // Count for task_a
         let count = ts.store.count_by_task(task_a).await.unwrap();
         assert_eq!(count, 2);
 
-        // Count for task_b
         let count = ts.store.count_by_task(task_b).await.unwrap();
         assert_eq!(count, 1);
     }
@@ -835,19 +774,16 @@ mod tests {
         setup_task(&ts, task_id).await;
         let mut job = create_test_job(task_id, "qwen3-vl:8b", vec![Uuid::new_v4(), Uuid::new_v4()]);
 
-        // Create job (Queued)
         ts.store.create(job.clone()).await.unwrap();
         let retrieved = ts.store.get(job.job_id).await.unwrap().unwrap();
         assert_eq!(retrieved.status, JobStatus::Queued);
 
-        // Start job (Processing)
         job.start();
         ts.store.update(job.clone()).await.unwrap();
         let retrieved = ts.store.get(job.job_id).await.unwrap().unwrap();
         assert_eq!(retrieved.status, JobStatus::Processing);
         assert!(retrieved.started_at.is_some());
 
-        // Complete job
         job.complete();
         ts.store.update(job.clone()).await.unwrap();
         let retrieved = ts.store.get(job.job_id).await.unwrap().unwrap();
@@ -856,16 +792,11 @@ mod tests {
         assert!(retrieved.is_finished());
     }
 
-    // ========================================================================
-    // Persistence Tests
-    // ========================================================================
-
     #[tokio::test]
     async fn test_persistence_survives_reload() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let storage_path = temp_dir.path().to_path_buf();
 
-        // Create store and add jobs
         let task_id = Uuid::new_v4();
         let catalog_id = Uuid::new_v4();
         let job1 = create_test_job(task_id, "qwen3-vl:8b", vec![Uuid::new_v4()]);
@@ -890,12 +821,10 @@ mod tests {
             assert_eq!(store.count_by_task(task_id).await.unwrap(), 2);
         }
 
-        // Create new store instance (simulates server restart)
         let task_store: Arc<dyn TaskStore> =
             Arc::new(FileSystemTaskStore::new(storage_path.clone()).await);
         let store = FileSystemJobStore::new(storage_path, task_store).await;
 
-        // Jobs should be loaded from filesystem
         assert_eq!(store.count_by_task(task_id).await.unwrap(), 2);
         assert!(store.exists(job1_id).await.unwrap());
         assert!(store.exists(job2_id).await.unwrap());
@@ -928,12 +857,10 @@ mod tests {
             let store = FileSystemJobStore::new(storage_path.clone(), task_store).await;
             store.create(job.clone()).await.unwrap();
 
-            // Update the job
             job.start();
             store.update(job.clone()).await.unwrap();
         }
 
-        // Reload and verify update persisted
         let task_store: Arc<dyn TaskStore> =
             Arc::new(FileSystemTaskStore::new(storage_path.clone()).await);
         let store = FileSystemJobStore::new(storage_path, task_store).await;
@@ -968,17 +895,12 @@ mod tests {
             store.delete(job_id).await.unwrap();
         }
 
-        // Reload and verify job is gone
         let task_store: Arc<dyn TaskStore> =
             Arc::new(FileSystemTaskStore::new(storage_path.clone()).await);
         let store = FileSystemJobStore::new(storage_path, task_store).await;
         assert_eq!(store.count_by_task(task_id).await.unwrap(), 0);
         assert!(!store.exists(job_id).await.unwrap());
     }
-
-    // ========================================================================
-    // Resilience Tests
-    // ========================================================================
 
     /// Simulates a failure writing the `.tmp` file by making the jobs directory
     /// non-writable, then verifies the in-memory job is unchanged.
@@ -1063,7 +985,6 @@ mod tests {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let storage_path = temp_dir.path().to_path_buf();
 
-        // Create multiple tasks with multiple jobs each
         let task_a = Uuid::new_v4();
         let task_b = Uuid::new_v4();
         let catalog_id = Uuid::new_v4();
@@ -1092,7 +1013,6 @@ mod tests {
             store.create(job4).await.unwrap();
         }
 
-        // Reload and verify all jobs loaded correctly
         let task_store: Arc<dyn TaskStore> =
             Arc::new(FileSystemTaskStore::new(storage_path.clone()).await);
         let store = FileSystemJobStore::new(storage_path, task_store).await;

--- a/api/src/storage/filesystem_job_store.rs
+++ b/api/src/storage/filesystem_job_store.rs
@@ -11,6 +11,7 @@ use async_trait::async_trait;
 use chrono::Local;
 use dashmap::DashMap;
 use dashmap::mapref::entry::Entry;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};
@@ -18,7 +19,7 @@ use uuid::Uuid;
 
 use crate::models::Job;
 
-use super::utils::{parse_uuid_from_dir, quarantine_move};
+use super::utils::{load_json_from_file, parse_uuid_from_dir, try_quarantine, try_scan_task_dirs};
 use super::{FileSystemLayout, JobStore, JobStoreError, JobStoreResult, TaskStore};
 
 fn sorted_jobs(iter: impl Iterator<Item = Job>) -> Vec<Job> {
@@ -135,15 +136,8 @@ impl FileSystemJobStore {
     /// Job files with corrupt, inconsistent, or unresolvable data are moved to
     /// the boot-scoped quarantine directory.
     async fn load_catalog_jobs(&self, catalog_id: Uuid) -> (usize, usize) {
-        let task_dirs = match self.layout.scan_task_dirs(catalog_id).await {
-            Ok(dirs) => dirs,
-            Err(e) => {
-                warn!(
-                    "Failed to scan task directories for catalog {}: {}",
-                    catalog_id, e
-                );
-                return (0, 1);
-            }
+        let Some(task_dirs) = try_scan_task_dirs(&self.layout, catalog_id).await else {
+            return (0, 1);
         };
 
         let mut loaded = 0;
@@ -165,38 +159,33 @@ impl FileSystemJobStore {
             };
 
             for job_path in job_files {
-                let filename_id = job_path
+                let Some(filename_id) = job_path
                     .file_stem()
                     .and_then(|s| s.to_str())
-                    .and_then(|s| s.parse::<Uuid>().ok());
+                    .and_then(|s| s.parse::<Uuid>().ok())
+                else {
+                    warn!("Skipping non-UUID job file: {:?}", job_path);
+                    continue;
+                };
 
-                let job = match self.load_job_from_file(&job_path).await {
+                let job = match load_json_from_file::<Job>(&job_path).await {
                     Ok(j) => j,
                     Err(e) => {
-                        error!(
-                            "Corrupt job file {:?}: {} — quarantining",
-                            job_path, e
-                        );
-                        if let Err(qe) = quarantine_move(&self.layout, &job_path).await {
-                            error!("Failed to quarantine {:?}: {}", job_path, qe);
-                        }
+                        error!("Corrupt job file {:?}: {} — quarantining", job_path, e);
+                        try_quarantine(&self.layout, &job_path).await;
                         errors += 1;
                         continue;
                     }
                 };
 
-                if let Some(fid) = filename_id {
-                    if fid != job.job_id {
-                        error!(
-                            "Inconsistent job file {:?}: job_id {} does not match filename {} — quarantining",
-                            job_path, job.job_id, fid
-                        );
-                        if let Err(qe) = quarantine_move(&self.layout, &job_path).await {
-                            error!("Failed to quarantine {:?}: {}", job_path, qe);
-                        }
-                        errors += 1;
-                        continue;
-                    }
+                if filename_id != job.job_id {
+                    error!(
+                        "Inconsistent job file {:?}: job_id {} does not match filename {} — quarantining",
+                        job_path, job.job_id, filename_id
+                    );
+                    try_quarantine(&self.layout, &job_path).await;
+                    errors += 1;
+                    continue;
                 }
 
                 if job.task_id != task_id {
@@ -204,9 +193,7 @@ impl FileSystemJobStore {
                         "Inconsistent job file {:?}: task_id {} does not match directory {} — quarantining",
                         job_path, job.task_id, task_id
                     );
-                    if let Err(qe) = quarantine_move(&self.layout, &job_path).await {
-                        error!("Failed to quarantine {:?}: {}", job_path, qe);
-                    }
+                    try_quarantine(&self.layout, &job_path).await;
                     errors += 1;
                     continue;
                 }
@@ -217,16 +204,6 @@ impl FileSystemJobStore {
         }
 
         (loaded, errors)
-    }
-
-    /// Loads a single job from a JSON file.
-    async fn load_job_from_file(&self, path: &Path) -> JobStoreResult<Job> {
-        let content = tokio::fs::read_to_string(path)
-            .await
-            .map_err(|e| JobStoreError::StorageError(format!("Failed to read job file: {}", e)))?;
-
-        serde_json::from_str(&content)
-            .map_err(|e| JobStoreError::StorageError(format!("Failed to parse job JSON: {}", e)))
     }
 
     /// Saves a job's metadata to the filesystem atomically.
@@ -368,7 +345,7 @@ impl JobStore for FileSystemJobStore {
             .job_file_path(catalog_id, job.task_id, job.job_id);
         match tokio::fs::remove_file(&job_path).await {
             Ok(()) => debug!("Removed job file: {:?}", job_path),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) if e.kind() == ErrorKind::NotFound => {}
             Err(e) => {
                 error!("Failed to remove job file {:?}: {}", job_path, e);
                 self.jobs.insert(job_id, job);
@@ -410,7 +387,7 @@ impl JobStore for FileSystemJobStore {
                     .job_file_path(catalog_id, job.task_id, job.job_id);
                 match tokio::fs::remove_file(&job_path).await {
                     Ok(()) => debug!("Removed job file: {:?}", job_path),
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(e) if e.kind() == ErrorKind::NotFound => {}
                     Err(e) => error!("Failed to remove job file {:?}: {}", job_path, e),
                 }
             }

--- a/api/src/storage/filesystem_job_store.rs
+++ b/api/src/storage/filesystem_job_store.rs
@@ -10,13 +10,14 @@
 use async_trait::async_trait;
 use dashmap::DashMap;
 use dashmap::mapref::entry::Entry;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crate::models::Job;
 
+use super::utils::parse_uuid_from_dir;
 use super::{FileSystemLayout, JobStore, JobStoreError, JobStoreResult, TaskStore};
 
 // ============================================================================
@@ -98,88 +99,74 @@ impl FileSystemJobStore {
             }
         };
 
-        let mut loaded_count = 0;
-        let mut error_count = 0;
+        let mut loaded = 0;
+        let mut errors = 0;
 
         for catalog_dir in catalog_dirs {
-            let catalog_id = match catalog_dir
-                .file_name()
-                .and_then(|n| n.to_str())
-                .and_then(|s| s.parse::<Uuid>().ok())
-            {
-                Some(id) => id,
-                None => {
-                    warn!("Skipping invalid catalog directory: {:?}", catalog_dir);
-                    continue;
-                }
-            };
-
-            let tasks_dir = self.layout.tasks_root(catalog_id);
-            if !tasks_dir.exists() {
+            let Some(catalog_id) = parse_uuid_from_dir(&catalog_dir) else {
+                warn!("Skipping invalid catalog directory: {:?}", catalog_dir);
                 continue;
-            }
+            };
+            let (n_loaded, n_errors) = self.load_catalog_jobs(catalog_id).await;
+            loaded += n_loaded;
+            errors += n_errors;
+        }
 
-            let mut task_entries = match tokio::fs::read_dir(&tasks_dir).await {
-                Ok(entries) => entries,
+        info!("Loaded {} jobs from filesystem ({} errors)", loaded, errors);
+    }
+
+    /// Loads all jobs for a single catalog from the filesystem.
+    ///
+    /// Returns the count of successfully loaded jobs and errors encountered.
+    async fn load_catalog_jobs(&self, catalog_id: Uuid) -> (usize, usize) {
+        let task_dirs = match self.layout.scan_task_dirs(catalog_id).await {
+            Ok(dirs) => dirs,
+            Err(e) => {
+                warn!(
+                    "Failed to scan task directories for catalog {}: {}",
+                    catalog_id, e
+                );
+                return (0, 1);
+            }
+        };
+
+        let mut loaded = 0;
+        let mut errors = 0;
+
+        for task_dir in task_dirs {
+            let Some(task_id) = parse_uuid_from_dir(&task_dir) else {
+                warn!("Skipping invalid task directory: {:?}", task_dir);
+                continue;
+            };
+
+            let job_files = match self.layout.scan_job_files(catalog_id, task_id).await {
+                Ok(files) => files,
                 Err(e) => {
-                    warn!(
-                        "Failed to read tasks directory for catalog {}: {}",
-                        catalog_id, e
-                    );
+                    warn!("Failed to scan jobs for task {}: {}", task_id, e);
+                    errors += 1;
                     continue;
                 }
             };
 
-            while let Ok(Some(task_entry)) = task_entries.next_entry().await {
-                let task_path = task_entry.path();
-                if !task_path.is_dir() {
-                    continue;
-                }
-
-                let task_id = match task_path
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .and_then(|s| s.parse::<Uuid>().ok())
-                {
-                    Some(id) => id,
-                    None => {
-                        warn!("Skipping invalid task directory: {:?}", task_path);
-                        continue;
+            for job_path in job_files {
+                match self.load_job_from_file(&job_path).await {
+                    Ok(job) => {
+                        self.jobs.insert(job.job_id, job);
+                        loaded += 1;
                     }
-                };
-
-                let job_files = match self.layout.scan_job_files(catalog_id, task_id).await {
-                    Ok(files) => files,
                     Err(e) => {
-                        warn!("Failed to scan jobs for task {}: {}", task_id, e);
-                        error_count += 1;
-                        continue;
-                    }
-                };
-
-                for job_path in job_files {
-                    match self.load_job_from_file(&job_path).await {
-                        Ok(job) => {
-                            self.jobs.insert(job.job_id, job);
-                            loaded_count += 1;
-                        }
-                        Err(e) => {
-                            warn!("Failed to load job from {:?}: {}", job_path, e);
-                            error_count += 1;
-                        }
+                        warn!("Failed to load job from {:?}: {}", job_path, e);
+                        errors += 1;
                     }
                 }
             }
         }
 
-        info!(
-            "Loaded {} jobs from filesystem ({} errors)",
-            loaded_count, error_count
-        );
+        (loaded, errors)
     }
 
     /// Loads a single job from a JSON file.
-    async fn load_job_from_file(&self, path: &PathBuf) -> JobStoreResult<Job> {
+    async fn load_job_from_file(&self, path: &Path) -> JobStoreResult<Job> {
         let content = tokio::fs::read_to_string(path)
             .await
             .map_err(|e| JobStoreError::StorageError(format!("Failed to read job file: {}", e)))?;

--- a/api/src/storage/filesystem_job_store.rs
+++ b/api/src/storage/filesystem_job_store.rs
@@ -17,7 +17,7 @@ use uuid::Uuid;
 
 use crate::models::Job;
 
-use super::utils::parse_uuid_from_dir;
+use super::utils::{parse_uuid_from_dir, quarantine_move};
 use super::{FileSystemLayout, JobStore, JobStoreError, JobStoreResult, TaskStore};
 
 fn sorted_jobs(iter: impl Iterator<Item = Job>) -> Vec<Job> {
@@ -119,6 +119,8 @@ impl FileSystemJobStore {
     /// Loads all jobs for a single catalog from the filesystem.
     ///
     /// Returns the count of successfully loaded jobs and errors encountered.
+    /// Job files with corrupt, inconsistent, or unresolvable data are moved to
+    /// the boot-scoped quarantine directory.
     async fn load_catalog_jobs(&self, catalog_id: Uuid) -> (usize, usize) {
         let task_dirs = match self.layout.scan_task_dirs(catalog_id).await {
             Ok(dirs) => dirs,
@@ -150,16 +152,54 @@ impl FileSystemJobStore {
             };
 
             for job_path in job_files {
-                match self.load_job_from_file(&job_path).await {
-                    Ok(job) => {
-                        self.jobs.insert(job.job_id, job);
-                        loaded += 1;
-                    }
+                let filename_id = job_path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .and_then(|s| s.parse::<Uuid>().ok());
+
+                let job = match self.load_job_from_file(&job_path).await {
+                    Ok(j) => j,
                     Err(e) => {
-                        warn!("Failed to load job from {:?}: {}", job_path, e);
+                        error!(
+                            "Corrupt job file {:?}: {} — quarantining",
+                            job_path, e
+                        );
+                        if let Err(qe) = quarantine_move(&self.layout, &job_path).await {
+                            error!("Failed to quarantine {:?}: {}", job_path, qe);
+                        }
                         errors += 1;
+                        continue;
+                    }
+                };
+
+                if let Some(fid) = filename_id {
+                    if fid != job.job_id {
+                        error!(
+                            "Inconsistent job file {:?}: job_id {} does not match filename {} — quarantining",
+                            job_path, job.job_id, fid
+                        );
+                        if let Err(qe) = quarantine_move(&self.layout, &job_path).await {
+                            error!("Failed to quarantine {:?}: {}", job_path, qe);
+                        }
+                        errors += 1;
+                        continue;
                     }
                 }
+
+                if job.task_id != task_id {
+                    error!(
+                        "Inconsistent job file {:?}: task_id {} does not match directory {} — quarantining",
+                        job_path, job.task_id, task_id
+                    );
+                    if let Err(qe) = quarantine_move(&self.layout, &job_path).await {
+                        error!("Failed to quarantine {:?}: {}", job_path, qe);
+                    }
+                    errors += 1;
+                    continue;
+                }
+
+                self.jobs.insert(job.job_id, job);
+                loaded += 1;
             }
         }
 
@@ -1019,5 +1059,119 @@ mod tests {
         assert_eq!(store.list().await.unwrap().len(), 4);
         assert_eq!(store.count_by_task(task_a).await.unwrap(), 2);
         assert_eq!(store.count_by_task(task_b).await.unwrap(), 2);
+    }
+
+    /// Sets up a task on disk and returns its catalog_id and the job file path for `job`.
+    async fn setup_task_and_job(
+        storage_path: &PathBuf,
+        task_id: Uuid,
+        catalog_id: Uuid,
+        job: &Job,
+    ) -> PathBuf {
+        let task_store: Arc<dyn TaskStore> =
+            Arc::new(FileSystemTaskStore::new(storage_path.clone()).await);
+        let task = Task {
+            task_id,
+            catalog_id,
+            name: "test".to_string(),
+            context: "ctx".to_string(),
+            created_at: Utc::now(),
+        };
+        task_store.create(task).await.unwrap();
+        let store = FileSystemJobStore::new(storage_path.clone(), task_store).await;
+        store.create(job.clone()).await.unwrap();
+        store
+            .layout
+            .job_file_path(catalog_id, task_id, job.job_id)
+    }
+
+    #[tokio::test]
+    async fn test_load_quarantines_corrupt_job_file() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let storage_path = temp_dir.path().to_path_buf();
+        let task_id = Uuid::new_v4();
+        let catalog_id = Uuid::new_v4();
+        let job = create_test_job(task_id, "llava", vec![Uuid::new_v4()]);
+        let job_id = job.job_id;
+
+        let job_file = setup_task_and_job(&storage_path, task_id, catalog_id, &job).await;
+        tokio::fs::write(&job_file, b"not valid json").await.unwrap();
+
+        let task_store: Arc<dyn TaskStore> =
+            Arc::new(FileSystemTaskStore::new(storage_path.clone()).await);
+        let store = FileSystemJobStore::new(storage_path, task_store).await;
+
+        assert!(!store.exists(job_id).await.unwrap());
+        assert!(!job_file.exists());
+        assert!(store.layout.quarantine_path_for(&job_file).exists());
+    }
+
+    #[tokio::test]
+    async fn test_load_quarantines_inconsistent_job_id() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let storage_path = temp_dir.path().to_path_buf();
+        let task_id = Uuid::new_v4();
+        let catalog_id = Uuid::new_v4();
+        let job = create_test_job(task_id, "llava", vec![Uuid::new_v4()]);
+
+        let job_file = setup_task_and_job(&storage_path, task_id, catalog_id, &job).await;
+
+        let mut tampered = job.clone();
+        tampered.job_id = Uuid::new_v4();
+        tokio::fs::write(&job_file, serde_json::to_string(&tampered).unwrap())
+            .await
+            .unwrap();
+
+        let task_store: Arc<dyn TaskStore> =
+            Arc::new(FileSystemTaskStore::new(storage_path.clone()).await);
+        let store = FileSystemJobStore::new(storage_path, task_store).await;
+
+        assert_eq!(store.count_by_task(task_id).await.unwrap(), 0);
+        assert!(!job_file.exists());
+        assert!(store.layout.quarantine_path_for(&job_file).exists());
+    }
+
+    #[tokio::test]
+    async fn test_load_quarantines_inconsistent_task_id() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let storage_path = temp_dir.path().to_path_buf();
+        let task_id = Uuid::new_v4();
+        let catalog_id = Uuid::new_v4();
+        let job = create_test_job(task_id, "llava", vec![Uuid::new_v4()]);
+
+        let job_file = setup_task_and_job(&storage_path, task_id, catalog_id, &job).await;
+
+        let mut tampered = job.clone();
+        tampered.task_id = Uuid::new_v4();
+        tokio::fs::write(&job_file, serde_json::to_string(&tampered).unwrap())
+            .await
+            .unwrap();
+
+        let task_store: Arc<dyn TaskStore> =
+            Arc::new(FileSystemTaskStore::new(storage_path.clone()).await);
+        let store = FileSystemJobStore::new(storage_path, task_store).await;
+
+        assert_eq!(store.count_by_task(task_id).await.unwrap(), 0);
+        assert!(!job_file.exists());
+        assert!(store.layout.quarantine_path_for(&job_file).exists());
+    }
+
+    #[tokio::test]
+    async fn test_load_valid_job_not_quarantined() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let storage_path = temp_dir.path().to_path_buf();
+        let task_id = Uuid::new_v4();
+        let catalog_id = Uuid::new_v4();
+        let job = create_test_job(task_id, "llava", vec![Uuid::new_v4()]);
+        let job_id = job.job_id;
+
+        setup_task_and_job(&storage_path, task_id, catalog_id, &job).await;
+
+        let task_store: Arc<dyn TaskStore> =
+            Arc::new(FileSystemTaskStore::new(storage_path.clone()).await);
+        let store = FileSystemJobStore::new(storage_path, task_store).await;
+
+        assert!(store.exists(job_id).await.unwrap());
+        assert!(!store.layout.quarantine_dir().exists());
     }
 }

--- a/api/src/storage/filesystem_job_store.rs
+++ b/api/src/storage/filesystem_job_store.rs
@@ -8,6 +8,7 @@
 //! within each task's directory.
 
 use async_trait::async_trait;
+use chrono::Local;
 use dashmap::DashMap;
 use dashmap::mapref::entry::Entry;
 use std::path::{Path, PathBuf};
@@ -63,9 +64,21 @@ impl FileSystemJobStore {
     /// * `storage_path` - Base path for storing task directories
     /// * `task_store` - Reference to the task store for resolving task-to-catalog relationships
     pub async fn new(storage_path: PathBuf, task_store: Arc<dyn TaskStore>) -> Self {
+        Self::new_with_boot_ts(storage_path, task_store, Local::now().format("%Y%m%d_%H%M%S").to_string()).await
+    }
+
+    /// Creates a new filesystem-backed job store with an explicit boot timestamp.
+    ///
+    /// Use this when multiple stores must share the same quarantine directory for
+    /// a single server boot.
+    pub async fn new_with_boot_ts(
+        storage_path: PathBuf,
+        task_store: Arc<dyn TaskStore>,
+        boot_ts: String,
+    ) -> Self {
         let store = Self {
             jobs: Arc::new(DashMap::new()),
-            layout: FileSystemLayout::new(storage_path),
+            layout: FileSystemLayout::new_with_boot_ts(storage_path, boot_ts),
             task_store,
         };
         store.load_all().await;

--- a/api/src/storage/filesystem_layout.rs
+++ b/api/src/storage/filesystem_layout.rs
@@ -219,10 +219,11 @@ impl FileSystemLayout {
         Ok(result)
     }
 
-    /// Scans the filesystem and returns paths to all task.json files within a catalog.
+    /// Scans the filesystem and returns paths to all task directories within a catalog.
     ///
-    /// Used by TaskStore during initialization to load existing tasks.
-    pub async fn scan_task_json_files(&self, catalog_id: Uuid) -> io::Result<Vec<PathBuf>> {
+    /// Returns all subdirectories under `tasks/`, regardless of their contents.
+    /// Used as the base primitive for more specific scan methods.
+    pub async fn scan_task_dirs(&self, catalog_id: Uuid) -> io::Result<Vec<PathBuf>> {
         let tasks_dir = self.tasks_root(catalog_id);
 
         if !tasks_dir.exists() {
@@ -234,45 +235,36 @@ impl FileSystemLayout {
 
         while let Some(entry) = entries.next_entry().await? {
             let path = entry.path();
-            if !path.is_dir() {
-                continue;
-            }
-
-            let task_json = path.join("task.json");
-            if task_json.exists() {
-                result.push(task_json);
+            if path.is_dir() {
+                result.push(path);
             }
         }
 
         Ok(result)
     }
 
+    /// Scans the filesystem and returns paths to all task.json files within a catalog.
+    ///
+    /// Used by TaskStore during initialization to load existing tasks.
+    pub async fn scan_task_json_files(&self, catalog_id: Uuid) -> io::Result<Vec<PathBuf>> {
+        let dirs = self.scan_task_dirs(catalog_id).await?;
+        Ok(dirs
+            .into_iter()
+            .map(|d| d.join("task.json"))
+            .filter(|p| p.exists())
+            .collect())
+    }
+
     /// Scans the filesystem and returns paths to all photos.json files within a catalog.
     ///
     /// Used by PhotoStore during initialization to load existing photos.
     pub async fn scan_photos_json_files(&self, catalog_id: Uuid) -> io::Result<Vec<PathBuf>> {
-        let tasks_dir = self.tasks_root(catalog_id);
-
-        if !tasks_dir.exists() {
-            return Ok(Vec::new());
-        }
-
-        let mut result = Vec::new();
-        let mut entries = tokio::fs::read_dir(&tasks_dir).await?;
-
-        while let Some(entry) = entries.next_entry().await? {
-            let path = entry.path();
-            if !path.is_dir() {
-                continue;
-            }
-
-            let photos_json = path.join("photos.json");
-            if photos_json.exists() {
-                result.push(photos_json);
-            }
-        }
-
-        Ok(result)
+        let dirs = self.scan_task_dirs(catalog_id).await?;
+        Ok(dirs
+            .into_iter()
+            .map(|d| d.join("photos.json"))
+            .filter(|p| p.exists())
+            .collect())
     }
 
     /// Checks if a photos.json file exists for a given task.
@@ -525,6 +517,37 @@ mod tests {
         layout.ensure_catalog_dir(catalog2_id).await.unwrap();
 
         let dirs = layout.scan_catalog_dirs().await.unwrap();
+        assert_eq!(dirs.len(), 2);
+
+        for dir in &dirs {
+            assert!(dir.exists());
+            assert!(dir.is_dir());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_scan_task_dirs_empty() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let layout = FileSystemLayout::new(temp_dir.path().to_path_buf());
+        let catalog_id = Uuid::new_v4();
+
+        let dirs = layout.scan_task_dirs(catalog_id).await.unwrap();
+        assert!(dirs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_scan_task_dirs() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let layout = FileSystemLayout::new(temp_dir.path().to_path_buf());
+        let catalog_id = Uuid::new_v4();
+
+        let task1_id = Uuid::new_v4();
+        let task2_id = Uuid::new_v4();
+
+        layout.ensure_task_dir(catalog_id, task1_id).await.unwrap();
+        layout.ensure_task_dir(catalog_id, task2_id).await.unwrap();
+
+        let dirs = layout.scan_task_dirs(catalog_id).await.unwrap();
         assert_eq!(dirs.len(), 2);
 
         for dir in &dirs {

--- a/api/src/storage/filesystem_layout.rs
+++ b/api/src/storage/filesystem_layout.rs
@@ -247,6 +247,34 @@ impl FileSystemLayout {
         Ok(result)
     }
 
+    /// Scans the filesystem and returns paths to all photos.json files within a catalog.
+    ///
+    /// Used by PhotoStore during initialization to load existing photos.
+    pub async fn scan_photos_json_files(&self, catalog_id: Uuid) -> io::Result<Vec<PathBuf>> {
+        let tasks_dir = self.tasks_root(catalog_id);
+
+        if !tasks_dir.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut result = Vec::new();
+        let mut entries = tokio::fs::read_dir(&tasks_dir).await?;
+
+        while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+
+            let photos_json = path.join("photos.json");
+            if photos_json.exists() {
+                result.push(photos_json);
+            }
+        }
+
+        Ok(result)
+    }
+
     /// Checks if a photos.json file exists for a given task.
     ///
     /// Returns Some(path) if the file exists, None otherwise.
@@ -545,6 +573,46 @@ mod tests {
         for file in &files {
             assert!(file.exists());
             assert!(file.ends_with("task.json"));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_scan_photos_json_files_empty() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let layout = FileSystemLayout::new(temp_dir.path().to_path_buf());
+        let catalog_id = Uuid::new_v4();
+
+        let files = layout.scan_photos_json_files(catalog_id).await.unwrap();
+        assert!(files.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_scan_photos_json_files() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let layout = FileSystemLayout::new(temp_dir.path().to_path_buf());
+        let catalog_id = Uuid::new_v4();
+
+        let task1_id = Uuid::new_v4();
+        let task2_id = Uuid::new_v4();
+        let task3_id = Uuid::new_v4();
+
+        layout.ensure_task_dir(catalog_id, task1_id).await.unwrap();
+        layout.ensure_task_dir(catalog_id, task2_id).await.unwrap();
+        layout.ensure_task_dir(catalog_id, task3_id).await.unwrap();
+
+        tokio::fs::write(layout.photos_json_path(catalog_id, task1_id), b"[]")
+            .await
+            .unwrap();
+        tokio::fs::write(layout.photos_json_path(catalog_id, task2_id), b"[]")
+            .await
+            .unwrap();
+
+        let files = layout.scan_photos_json_files(catalog_id).await.unwrap();
+        assert_eq!(files.len(), 2);
+
+        for file in &files {
+            assert!(file.exists());
+            assert!(file.ends_with("photos.json"));
         }
     }
 

--- a/api/src/storage/filesystem_layout.rs
+++ b/api/src/storage/filesystem_layout.rs
@@ -64,10 +64,17 @@ impl FileSystemLayout {
     /// The boot timestamp is captured at construction time and used to namespace
     /// any quarantine directories created during this server boot.
     pub fn new(storage_path: PathBuf) -> Self {
-        Self {
-            storage_path,
-            boot_ts: Local::now().format("%Y%m%d_%H%M%S").to_string(),
-        }
+        Self::new_with_boot_ts(storage_path, Local::now().format("%Y%m%d_%H%M%S").to_string())
+    }
+
+    /// Creates a new layout with an explicit boot timestamp.
+    ///
+    /// Use this when multiple stores must share the same quarantine directory for
+    /// a single server boot (e.g., all stores initialized in [`startup`]).
+    ///
+    /// [`startup`]: crate::startup
+    pub fn new_with_boot_ts(storage_path: PathBuf, boot_ts: String) -> Self {
+        Self { storage_path, boot_ts }
     }
 
     /// Returns the boot timestamp string used to namespace the quarantine directory.

--- a/api/src/storage/filesystem_layout.rs
+++ b/api/src/storage/filesystem_layout.rs
@@ -12,6 +12,7 @@
 //! [`FileSystemPhotoStore`]: crate::storage::FileSystemPhotoStore
 //! [`FileSystemJobStore`]: crate::storage::FileSystemJobStore
 
+use chrono::Local;
 use std::io;
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
@@ -32,28 +33,46 @@ use uuid::Uuid;
 ///
 /// ```text
 /// {storage_path}/
-/// └── catalogs/
-///     └── {catalog_id}/
-///         ├── catalog.json       # Catalog metadata
-///         └── tasks/
-///             └── {task_id}/
-///                 ├── task.json          # Task metadata
-///                 ├── photos.json        # Photos metadata
-///                 ├── imgs/              # Photo binary data
-///                 │   ├── {photo_id_1}
-///                 │   └── {photo_id_2}
-///                 └── jobs/              # Job metadata
-///                     ├── {job_id_1}.json
-///                     └── {job_id_2}.json
+/// ├── catalogs/
+/// │   └── {catalog_id}/
+/// │       ├── catalog.json       # Catalog metadata
+/// │       └── tasks/
+/// │           └── {task_id}/
+/// │               ├── task.json          # Task metadata
+/// │               ├── photos.json        # Photos metadata
+/// │               ├── imgs/              # Photo binary data
+/// │               │   ├── {photo_id_1}
+/// │               │   └── {photo_id_2}
+/// │               └── jobs/              # Job metadata
+/// │                   ├── {job_id_1}.json
+/// │                   └── {job_id_2}.json
+/// └── quarantine/
+///     └── {boot_ts}/             # One dir per server boot that found anomalies
+///         └── catalogs/          # Mirrors the catalogs/ hierarchy
+///             └── {catalog_id}/
+///                 └── tasks/
+///                     └── {task_id}/     # Quarantined task dir or files
 /// ```
 pub struct FileSystemLayout {
     storage_path: PathBuf,
+    boot_ts: String,
 }
 
 impl FileSystemLayout {
     /// Creates a new layout with the given storage root path.
+    ///
+    /// The boot timestamp is captured at construction time and used to namespace
+    /// any quarantine directories created during this server boot.
     pub fn new(storage_path: PathBuf) -> Self {
-        Self { storage_path }
+        Self {
+            storage_path,
+            boot_ts: Local::now().format("%Y%m%d_%H%M%S").to_string(),
+        }
+    }
+
+    /// Returns the boot timestamp string used to namespace the quarantine directory.
+    pub fn boot_ts(&self) -> &str {
+        &self.boot_ts
     }
 
     // ========================================================================
@@ -304,6 +323,31 @@ impl FileSystemLayout {
     }
 
     // ========================================================================
+    // Quarantine Paths
+    // ========================================================================
+
+    /// Returns the quarantine directory for the current server boot.
+    ///
+    /// Example: `{storage_path}/quarantine/20260409_153012/`
+    pub fn quarantine_dir(&self) -> PathBuf {
+        self.storage_path.join("quarantine").join(&self.boot_ts)
+    }
+
+    /// Maps a storage path to its quarantine equivalent for the current boot.
+    ///
+    /// Preserves the path hierarchy relative to the storage root.
+    ///
+    /// Example:
+    /// - original: `{storage_path}/catalogs/{catalog_id}/tasks/{task_id}/task.json`
+    /// - quarantine: `{storage_path}/quarantine/{boot_ts}/catalogs/{catalog_id}/tasks/{task_id}/task.json`
+    pub fn quarantine_path_for(&self, path: &Path) -> PathBuf {
+        let relative = path
+            .strip_prefix(&self.storage_path)
+            .unwrap_or(path);
+        self.quarantine_dir().join(relative)
+    }
+
+    // ========================================================================
     // Utility Methods
     // ========================================================================
 
@@ -327,6 +371,66 @@ mod tests {
         let storage_path = PathBuf::from("/tmp/storage");
         let layout = FileSystemLayout::new(storage_path.clone());
         assert_eq!(layout.root(), storage_path.as_path());
+        assert!(!layout.boot_ts().is_empty());
+    }
+
+    #[test]
+    fn test_boot_ts_stable() {
+        let layout = FileSystemLayout::new(PathBuf::from("/tmp/storage"));
+        let ts1 = layout.boot_ts().to_string();
+        let ts2 = layout.boot_ts().to_string();
+        assert_eq!(ts1, ts2);
+    }
+
+    #[test]
+    fn test_quarantine_dir() {
+        let storage_path = PathBuf::from("/tmp/storage");
+        let layout = FileSystemLayout::new(storage_path.clone());
+        let expected = storage_path.join("quarantine").join(layout.boot_ts());
+        assert_eq!(layout.quarantine_dir(), expected);
+    }
+
+    #[test]
+    fn test_quarantine_path_for() {
+        let storage_path = PathBuf::from("/tmp/storage");
+        let layout = FileSystemLayout::new(storage_path.clone());
+        let catalog_id = Uuid::new_v4();
+        let task_id = Uuid::new_v4();
+
+        let original = storage_path
+            .join("catalogs")
+            .join(catalog_id.to_string())
+            .join("tasks")
+            .join(task_id.to_string())
+            .join("task.json");
+
+        let quarantine = layout.quarantine_path_for(&original);
+
+        let expected = storage_path
+            .join("quarantine")
+            .join(layout.boot_ts())
+            .join("catalogs")
+            .join(catalog_id.to_string())
+            .join("tasks")
+            .join(task_id.to_string())
+            .join("task.json");
+
+        assert_eq!(quarantine, expected);
+    }
+
+    #[test]
+    fn test_quarantine_path_for_preserves_hierarchy() {
+        let storage_path = PathBuf::from("/tmp/storage");
+        let layout = FileSystemLayout::new(storage_path.clone());
+        let catalog_id = Uuid::new_v4();
+        let task_id = Uuid::new_v4();
+        let job_id = Uuid::new_v4();
+
+        let original = layout.job_file_path(catalog_id, task_id, job_id);
+        let quarantine = layout.quarantine_path_for(&original);
+
+        assert!(quarantine.starts_with(layout.quarantine_dir()));
+        assert!(quarantine.ends_with(format!("{}.json", job_id)));
     }
 
     #[test]

--- a/api/src/storage/filesystem_photo_store.rs
+++ b/api/src/storage/filesystem_photo_store.rs
@@ -10,13 +10,14 @@
 use async_trait::async_trait;
 use dashmap::DashMap;
 use dashmap::mapref::entry::Entry;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crate::models::Photo;
 
+use super::utils::parse_uuid_from_dir;
 use super::{FileSystemLayout, PhotoStore, PhotoStoreError, PhotoStoreResult, TaskStore};
 
 // ============================================================================
@@ -102,72 +103,75 @@ impl FileSystemPhotoStore {
             }
         };
 
-        let mut loaded_count = 0;
-        let mut error_count = 0;
+        let mut loaded = 0;
+        let mut errors = 0;
 
         for catalog_dir in catalog_dirs {
-            let catalog_id = match catalog_dir
-                .file_name()
-                .and_then(|n| n.to_str())
-                .and_then(|s| s.parse::<Uuid>().ok())
-            {
-                Some(id) => id,
-                None => {
-                    warn!("Skipping invalid catalog directory: {:?}", catalog_dir);
-                    continue;
-                }
+            let Some(catalog_id) = parse_uuid_from_dir(&catalog_dir) else {
+                warn!("Skipping invalid catalog directory: {:?}", catalog_dir);
+                continue;
             };
+            let (n_loaded, n_errors) = self.load_catalog_photos(catalog_id).await;
+            loaded += n_loaded;
+            errors += n_errors;
+        }
 
-            let tasks_dir = self.layout.tasks_root(catalog_id);
-            if !tasks_dir.exists() {
+        info!("Loaded {} photos from filesystem ({} errors)", loaded, errors);
+    }
+
+    /// Loads all photos for a single catalog from the filesystem.
+    ///
+    /// Returns the count of successfully loaded photos and errors encountered.
+    async fn load_catalog_photos(&self, catalog_id: Uuid) -> (usize, usize) {
+        let tasks_dir = self.layout.tasks_root(catalog_id);
+        if !tasks_dir.exists() {
+            return (0, 0);
+        }
+
+        let mut entries = match tokio::fs::read_dir(&tasks_dir).await {
+            Ok(entries) => entries,
+            Err(e) => {
+                warn!(
+                    "Failed to read tasks directory for catalog {}: {}",
+                    catalog_id, e
+                );
+                return (0, 1);
+            }
+        };
+
+        let mut loaded = 0;
+        let mut errors = 0;
+
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            let path = entry.path();
+            if !path.is_dir() {
                 continue;
             }
 
-            let mut entries = match tokio::fs::read_dir(&tasks_dir).await {
-                Ok(entries) => entries,
+            let photos_json = path.join("photos.json");
+            if !photos_json.exists() {
+                continue;
+            }
+
+            match self.load_photos_from_file(&photos_json).await {
+                Ok(photos) => {
+                    loaded += photos.len();
+                    for photo in photos {
+                        self.photos.insert(photo.photo_id, photo);
+                    }
+                }
                 Err(e) => {
-                    warn!(
-                        "Failed to read tasks directory for catalog {}: {}",
-                        catalog_id, e
-                    );
-                    continue;
-                }
-            };
-
-            while let Ok(Some(entry)) = entries.next_entry().await {
-                let path = entry.path();
-                if !path.is_dir() {
-                    continue;
-                }
-
-                let photos_json = path.join("photos.json");
-                if !photos_json.exists() {
-                    continue;
-                }
-
-                match self.load_photos_from_file(&photos_json).await {
-                    Ok(photos) => {
-                        for photo in photos {
-                            self.photos.insert(photo.photo_id, photo);
-                            loaded_count += 1;
-                        }
-                    }
-                    Err(e) => {
-                        warn!("Failed to load photos from {:?}: {}", photos_json, e);
-                        error_count += 1;
-                    }
+                    warn!("Failed to load photos from {:?}: {}", photos_json, e);
+                    errors += 1;
                 }
             }
         }
 
-        info!(
-            "Loaded {} photos from filesystem ({} errors)",
-            loaded_count, error_count
-        );
+        (loaded, errors)
     }
 
     /// Loads photos from a JSON file.
-    async fn load_photos_from_file(&self, path: &PathBuf) -> PhotoStoreResult<Vec<Photo>> {
+    async fn load_photos_from_file(&self, path: &Path) -> PhotoStoreResult<Vec<Photo>> {
         let content = tokio::fs::read_to_string(path).await.map_err(|e| {
             PhotoStoreError::StorageError(format!("Failed to read photos file: {}", e))
         })?;

--- a/api/src/storage/filesystem_photo_store.rs
+++ b/api/src/storage/filesystem_photo_store.rs
@@ -17,7 +17,7 @@ use uuid::Uuid;
 
 use crate::models::Photo;
 
-use super::utils::parse_uuid_from_dir;
+use super::utils::{parse_uuid_from_dir, quarantine_move, quarantine_write};
 use super::{FileSystemLayout, PhotoStore, PhotoStoreError, PhotoStoreResult, TaskStore};
 
 /// Filesystem-backed implementation of PhotoStore with full persistence.
@@ -139,7 +139,13 @@ impl FileSystemPhotoStore {
                     }
                 }
                 Err(e) => {
-                    warn!("Failed to load photos from {:?}: {}", photos_json, e);
+                    error!(
+                        "Corrupt photos.json at {:?}: {} — quarantining",
+                        photos_json, e
+                    );
+                    if let Err(qe) = quarantine_move(&self.layout, &photos_json).await {
+                        error!("Failed to quarantine {:?}: {}", photos_json, qe);
+                    }
                     errors += 1;
                 }
             }
@@ -148,15 +154,77 @@ impl FileSystemPhotoStore {
         (loaded, errors)
     }
 
-    /// Loads photos from a JSON file.
+    /// Loads photos from a JSON file, with partial recovery for bad records.
+    ///
+    /// If the file is completely unparseable, returns `Err` — the caller is
+    /// responsible for quarantining it. If some records are valid and some are not,
+    /// the bad records are written to quarantine and the file is rewritten with only
+    /// the good records. If all records are invalid, returns `Err`.
     async fn load_photos_from_file(&self, path: &Path) -> PhotoStoreResult<Vec<Photo>> {
         let content = tokio::fs::read_to_string(path).await.map_err(|e| {
             PhotoStoreError::StorageError(format!("Failed to read photos file: {}", e))
         })?;
 
-        serde_json::from_str(&content).map_err(|e| {
+        let raw: Vec<serde_json::Value> = serde_json::from_str(&content).map_err(|e| {
             PhotoStoreError::StorageError(format!("Failed to parse photos JSON: {}", e))
-        })
+        })?;
+
+        let mut good = Vec::new();
+        let mut bad = Vec::new();
+
+        for value in raw {
+            match serde_json::from_value::<Photo>(value.clone()) {
+                Ok(photo) => good.push(photo),
+                Err(e) => {
+                    warn!("Invalid photo record in {:?}: {}", path, e);
+                    bad.push(value);
+                }
+            }
+        }
+
+        if bad.is_empty() {
+            return Ok(good);
+        }
+
+        if good.is_empty() {
+            return Err(PhotoStoreError::StorageError(format!(
+                "All {} photo records in {:?} are invalid",
+                bad.len(),
+                path
+            )));
+        }
+
+        if let Ok(bad_json) = serde_json::to_vec_pretty(&bad) {
+            if let Err(e) = quarantine_write(&self.layout, path, &bad_json).await {
+                error!(
+                    "Failed to write quarantine for bad records in {:?}: {}",
+                    path, e
+                );
+            }
+        }
+
+        let good_json = serde_json::to_string_pretty(&good).map_err(|e| {
+            PhotoStoreError::StorageError(format!("Failed to serialize corrected photos: {}", e))
+        })?;
+        let tmp_path = path.with_extension("tmp");
+        tokio::fs::write(&tmp_path, &good_json).await.map_err(|e| {
+            PhotoStoreError::StorageError(format!("Failed to write corrected photos file: {}", e))
+        })?;
+        tokio::fs::rename(&tmp_path, path).await.map_err(|e| {
+            PhotoStoreError::StorageError(format!(
+                "Failed to atomically save corrected photos: {}",
+                e
+            ))
+        })?;
+
+        info!(
+            "Partial recovery in {:?}: kept {} records, quarantined {} bad records",
+            path,
+            good.len(),
+            bad.len()
+        );
+
+        Ok(good)
     }
 
     /// Saves all photos for a task to the filesystem.
@@ -1073,5 +1141,141 @@ mod tests {
         let results = ts.store.find_by_client_id(task_id, "lr:42").await.unwrap();
 
         assert!(results.is_empty());
+    }
+
+    /// Creates the storage structure for a task and writes the given content to photos.json.
+    /// Prerequisite: a valid task.json must already exist (created via task_store) so that
+    /// the task store does not quarantine the directory on load.
+    async fn write_photos_json(storage_path: &PathBuf, catalog_id: Uuid, task_id: Uuid, content: &[u8]) -> PathBuf {
+        let photos_json = storage_path
+            .join("catalogs")
+            .join(catalog_id.to_string())
+            .join("tasks")
+            .join(task_id.to_string())
+            .join("photos.json");
+        tokio::fs::write(&photos_json, content).await.unwrap();
+        photos_json
+    }
+
+    /// Creates a task on disk and returns its catalog_id, ready for photo tests.
+    async fn setup_task_on_disk(storage_path: &PathBuf, task_id: Uuid) -> (Arc<dyn TaskStore>, Uuid) {
+        let task_store: Arc<dyn TaskStore> =
+            Arc::new(FileSystemTaskStore::new(storage_path.clone()).await);
+        let catalog_id = Uuid::new_v4();
+        let task = Task {
+            task_id,
+            catalog_id,
+            name: "test".to_string(),
+            context: "ctx".to_string(),
+            created_at: Utc::now(),
+        };
+        task_store.create(task).await.unwrap();
+        (task_store, catalog_id)
+    }
+
+    #[tokio::test]
+    async fn test_load_quarantines_corrupt_photos_json() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let storage_path = temp_dir.path().to_path_buf();
+        let task_id = Uuid::new_v4();
+
+        let (task_store, catalog_id) = setup_task_on_disk(&storage_path, task_id).await;
+        let photos_json = write_photos_json(&storage_path, catalog_id, task_id, b"not valid json").await;
+
+        let store = FileSystemPhotoStore::new(storage_path, task_store).await;
+
+        assert_eq!(store.count_by_task(task_id).await.unwrap(), 0);
+        assert!(!photos_json.exists());
+        assert!(store.layout.quarantine_path_for(&photos_json).exists());
+    }
+
+    #[tokio::test]
+    async fn test_load_quarantines_all_bad_records() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let storage_path = temp_dir.path().to_path_buf();
+        let task_id = Uuid::new_v4();
+
+        let (task_store, catalog_id) = setup_task_on_disk(&storage_path, task_id).await;
+        let photos_json = write_photos_json(
+            &storage_path,
+            catalog_id,
+            task_id,
+            b"[{\"invalid\": true}, {\"also\": \"bad\"}]",
+        ).await;
+
+        let store = FileSystemPhotoStore::new(storage_path, task_store).await;
+
+        assert_eq!(store.count_by_task(task_id).await.unwrap(), 0);
+        assert!(!photos_json.exists());
+        assert!(store.layout.quarantine_path_for(&photos_json).exists());
+    }
+
+    #[tokio::test]
+    async fn test_load_partial_recovery_bad_records() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let storage_path = temp_dir.path().to_path_buf();
+        let task_id = Uuid::new_v4();
+
+        let (task_store, catalog_id) = setup_task_on_disk(&storage_path, task_id).await;
+
+        let good_photo = Photo::new(task_id, None, "good.jpg".to_string(), 1000);
+        let bad_record = serde_json::json!({"invalid": true});
+        let mixed = serde_json::json!([good_photo, bad_record]);
+        let photos_json = write_photos_json(
+            &storage_path,
+            catalog_id,
+            task_id,
+            &serde_json::to_vec(&mixed).unwrap(),
+        ).await;
+
+        let store = FileSystemPhotoStore::new(storage_path, task_store).await;
+
+        assert_eq!(store.count_by_task(task_id).await.unwrap(), 1);
+        assert!(store.exists(good_photo.photo_id).await.unwrap());
+
+        assert!(photos_json.exists());
+        let corrected: Vec<Photo> =
+            serde_json::from_str(&tokio::fs::read_to_string(&photos_json).await.unwrap())
+                .unwrap();
+        assert_eq!(corrected.len(), 1);
+        assert_eq!(corrected[0].photo_id, good_photo.photo_id);
+
+        let quarantine_path = store.layout.quarantine_path_for(&photos_json);
+        assert!(quarantine_path.exists());
+        let quarantined: Vec<serde_json::Value> =
+            serde_json::from_str(&tokio::fs::read_to_string(&quarantine_path).await.unwrap())
+                .unwrap();
+        assert_eq!(quarantined.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_load_valid_photos_not_quarantined() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let storage_path = temp_dir.path().to_path_buf();
+
+        let task_store: Arc<dyn TaskStore> =
+            Arc::new(FileSystemTaskStore::new(storage_path.clone()).await);
+        let task_id = Uuid::new_v4();
+        let catalog_id = Uuid::new_v4();
+        let task = Task {
+            task_id,
+            catalog_id,
+            name: "test".to_string(),
+            context: "ctx".to_string(),
+            created_at: Utc::now(),
+        };
+        task_store.create(task).await.unwrap();
+
+        {
+            let store =
+                FileSystemPhotoStore::new(storage_path.clone(), task_store.clone()).await;
+            let photo = create_test_photo(task_id, "valid.jpg", 2000);
+            store.create(photo).await.unwrap();
+        }
+
+        let store = FileSystemPhotoStore::new(storage_path, task_store).await;
+
+        assert_eq!(store.count_by_task(task_id).await.unwrap(), 1);
+        assert!(!store.layout.quarantine_dir().exists());
     }
 }

--- a/api/src/storage/filesystem_photo_store.rs
+++ b/api/src/storage/filesystem_photo_store.rs
@@ -11,6 +11,7 @@ use async_trait::async_trait;
 use chrono::Local;
 use dashmap::DashMap;
 use dashmap::mapref::entry::Entry;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};
@@ -18,7 +19,7 @@ use uuid::Uuid;
 
 use crate::models::Photo;
 
-use super::utils::{parse_uuid_from_dir, quarantine_move, quarantine_write};
+use super::utils::{load_json_from_file, parse_uuid_from_dir, quarantine_write, try_quarantine};
 use super::{FileSystemLayout, PhotoStore, PhotoStoreError, PhotoStoreResult, TaskStore};
 
 /// Filesystem-backed implementation of PhotoStore with full persistence.
@@ -156,9 +157,7 @@ impl FileSystemPhotoStore {
                         "Corrupt photos.json at {:?}: {} — quarantining",
                         photos_json, e
                     );
-                    if let Err(qe) = quarantine_move(&self.layout, &photos_json).await {
-                        error!("Failed to quarantine {:?}: {}", photos_json, qe);
-                    }
+                    try_quarantine(&self.layout, &photos_json).await;
                     errors += 1;
                 }
             }
@@ -174,12 +173,8 @@ impl FileSystemPhotoStore {
     /// the bad records are written to quarantine and the file is rewritten with only
     /// the good records. If all records are invalid, returns `Err`.
     async fn load_photos_from_file(&self, path: &Path) -> PhotoStoreResult<Vec<Photo>> {
-        let content = tokio::fs::read_to_string(path).await.map_err(|e| {
-            PhotoStoreError::StorageError(format!("Failed to read photos file: {}", e))
-        })?;
-
-        let raw: Vec<serde_json::Value> = serde_json::from_str(&content).map_err(|e| {
-            PhotoStoreError::StorageError(format!("Failed to parse photos JSON: {}", e))
+        let raw: Vec<serde_json::Value> = load_json_from_file(path).await.map_err(|e| {
+            PhotoStoreError::StorageError(format!("Failed to load photos file: {}", e))
         })?;
 
         let mut good = Vec::new();
@@ -254,7 +249,7 @@ impl FileSystemPhotoStore {
         if photos.is_empty() {
             match tokio::fs::remove_file(&path).await {
                 Ok(()) => {}
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) if e.kind() == ErrorKind::NotFound => {}
                 Err(e) => debug!("Failed to remove empty photos.json: {}", e),
             }
             return Ok(());
@@ -292,7 +287,7 @@ impl FileSystemPhotoStore {
             .photo_file_path(catalog_id, photo.task_id, photo.photo_id);
         match tokio::fs::remove_file(&file_path).await {
             Ok(()) => debug!("Removed photo file: {:?}", file_path),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) if e.kind() == ErrorKind::NotFound => {}
             Err(e) => error!("Failed to remove photo file {:?}: {}", file_path, e),
         }
 
@@ -303,7 +298,6 @@ impl FileSystemPhotoStore {
         Ok(())
     }
 }
-
 
 #[async_trait]
 impl PhotoStore for FileSystemPhotoStore {
@@ -534,7 +528,7 @@ impl PhotoStore for FileSystemPhotoStore {
                 .photo_file_path(catalog_id, photo_clone.task_id, photo_clone.photo_id);
         let data = tokio::fs::read(&file_path).await.map_err(|e| {
             error!("Failed to read photo file {:?}: {}", file_path, e);
-            if e.kind() == std::io::ErrorKind::NotFound {
+            if e.kind() == ErrorKind::NotFound {
                 PhotoStoreError::NotFound(photo_id)
             } else {
                 PhotoStoreError::StorageError(format!("Failed to read photo file: {}", e))
@@ -558,7 +552,7 @@ impl PhotoStore for FileSystemPhotoStore {
                     .photo_file_path(catalog_id, photo_clone.task_id, photo_clone.photo_id);
             match tokio::fs::remove_file(&file_path).await {
                 Ok(()) => {}
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) if e.kind() == ErrorKind::NotFound => {}
                 Err(e) => error!("Failed to remove photo file {:?}: {}", file_path, e),
             }
         }

--- a/api/src/storage/filesystem_photo_store.rs
+++ b/api/src/storage/filesystem_photo_store.rs
@@ -20,10 +20,6 @@ use crate::models::Photo;
 use super::utils::parse_uuid_from_dir;
 use super::{FileSystemLayout, PhotoStore, PhotoStoreError, PhotoStoreResult, TaskStore};
 
-// ============================================================================
-// FileSystemPhotoStore Implementation
-// ============================================================================
-
 /// Filesystem-backed implementation of PhotoStore with full persistence.
 ///
 /// This implementation stores photo metadata both in memory (using DashMap for
@@ -46,11 +42,8 @@ use super::{FileSystemLayout, PhotoStore, PhotoStoreError, PhotoStoreResult, Tas
 ///
 /// For details on the filesystem layout, see [`FileSystemLayout`]
 pub struct FileSystemPhotoStore {
-    /// Photo metadata storage
     photos: Arc<DashMap<Uuid, Photo>>,
-    /// Filesystem layout manager
     layout: FileSystemLayout,
-    /// Reference to the task store for resolving catalog identity
     task_store: Arc<dyn TaskStore>,
 }
 
@@ -123,16 +116,11 @@ impl FileSystemPhotoStore {
     ///
     /// Returns the count of successfully loaded photos and errors encountered.
     async fn load_catalog_photos(&self, catalog_id: Uuid) -> (usize, usize) {
-        let tasks_dir = self.layout.tasks_root(catalog_id);
-        if !tasks_dir.exists() {
-            return (0, 0);
-        }
-
-        let mut entries = match tokio::fs::read_dir(&tasks_dir).await {
-            Ok(entries) => entries,
+        let photos_files = match self.layout.scan_photos_json_files(catalog_id).await {
+            Ok(files) => files,
             Err(e) => {
                 warn!(
-                    "Failed to read tasks directory for catalog {}: {}",
+                    "Failed to scan photos files for catalog {}: {}",
                     catalog_id, e
                 );
                 return (0, 1);
@@ -142,17 +130,7 @@ impl FileSystemPhotoStore {
         let mut loaded = 0;
         let mut errors = 0;
 
-        while let Ok(Some(entry)) = entries.next_entry().await {
-            let path = entry.path();
-            if !path.is_dir() {
-                continue;
-            }
-
-            let photos_json = path.join("photos.json");
-            if !photos_json.exists() {
-                continue;
-            }
-
+        for photos_json in photos_files {
             match self.load_photos_from_file(&photos_json).await {
                 Ok(photos) => {
                     loaded += photos.len();
@@ -192,12 +170,11 @@ impl FileSystemPhotoStore {
 
         let path = self.layout.photos_json_path(catalog_id, task_id);
 
-        // If no photos, remove the file if it exists
         if photos.is_empty() {
-            if path.exists() {
-                if let Err(e) = tokio::fs::remove_file(&path).await {
-                    debug!("Failed to remove empty photos.json: {}", e);
-                }
+            match tokio::fs::remove_file(&path).await {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => debug!("Failed to remove empty photos.json: {}", e),
             }
             return Ok(());
         }
@@ -232,12 +209,10 @@ impl FileSystemPhotoStore {
         let file_path = self
             .layout
             .photo_file_path(catalog_id, photo.task_id, photo.photo_id);
-        if file_path.exists() {
-            if let Err(e) = tokio::fs::remove_file(&file_path).await {
-                error!("Failed to remove photo file {:?}: {}", file_path, e);
-            } else {
-                debug!("Removed photo file: {:?}", file_path);
-            }
+        match tokio::fs::remove_file(&file_path).await {
+            Ok(()) => debug!("Removed photo file: {:?}", file_path),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => error!("Failed to remove photo file {:?}: {}", file_path, e),
         }
 
         info!(
@@ -248,9 +223,6 @@ impl FileSystemPhotoStore {
     }
 }
 
-// ============================================================================
-// PhotoStore Trait Implementation
-// ============================================================================
 
 #[async_trait]
 impl PhotoStore for FileSystemPhotoStore {
@@ -267,9 +239,7 @@ impl PhotoStore for FileSystemPhotoStore {
             Entry::Vacant(entry) => {
                 entry.insert(photo.clone());
 
-                // Save updated photos.json
                 if let Err(e) = self.save_photos_for_task(catalog_id, task_id).await {
-                    // Rollback on failure
                     self.photos.remove(&photo_id);
                     return Err(e);
                 }
@@ -302,7 +272,6 @@ impl PhotoStore for FileSystemPhotoStore {
             .map(|entry| entry.value().clone())
             .collect();
 
-        // Sort by uploaded_at (oldest first) for deterministic output
         photos.sort_by_key(|photo| photo.uploaded_at);
 
         info!("Listed {} photos for task {}", photos.len(), task_id);
@@ -369,7 +338,6 @@ impl PhotoStore for FileSystemPhotoStore {
     async fn delete_by_task(&self, task_id: Uuid) -> PhotoStoreResult<usize> {
         debug!("Deleting all photos for task: {}", task_id);
 
-        // Collect photo_ids to delete (can't delete while iterating)
         let photo_ids: Vec<Uuid> = self
             .photos
             .iter()
@@ -379,13 +347,9 @@ impl PhotoStore for FileSystemPhotoStore {
 
         let count = photo_ids.len();
 
-        // Remove metadata - files are deleted by TaskStore::delete()
-        // when it removes the entire task directory
         for photo_id in &photo_ids {
             self.photos.remove(photo_id);
         }
-
-        // No need to save photos.json - the directory will be deleted
 
         info!("Deleted {} photos for task {}", count, task_id);
         Ok(count)
@@ -437,17 +401,15 @@ impl PhotoStore for FileSystemPhotoStore {
     async fn save_data(&self, photo_id: Uuid, data: &[u8]) -> PhotoStoreResult<()> {
         debug!("Saving {} bytes for photo: {}", data.len(), photo_id);
 
-        // Get photo metadata
         let photo = self
             .photos
             .get(&photo_id)
             .ok_or(PhotoStoreError::NotFound(photo_id))?;
         let photo_clone = photo.value().clone();
-        drop(photo); // Release the lock
+        drop(photo);
 
         let catalog_id = self.resolve_catalog_id(photo_clone.task_id).await?;
 
-        // Ensure imgs directory exists
         let imgs_dir = self
             .layout
             .ensure_photos_dir(catalog_id, photo_clone.task_id)
@@ -478,13 +440,12 @@ impl PhotoStore for FileSystemPhotoStore {
     async fn load_data(&self, photo_id: Uuid) -> PhotoStoreResult<Vec<u8>> {
         debug!("Loading data for photo: {}", photo_id);
 
-        // Get photo metadata
         let photo = self
             .photos
             .get(&photo_id)
             .ok_or(PhotoStoreError::NotFound(photo_id))?;
         let photo_clone = photo.value().clone();
-        drop(photo); // Release the lock
+        drop(photo);
 
         let catalog_id = self.resolve_catalog_id(photo_clone.task_id).await?;
         let file_path =
@@ -506,29 +467,23 @@ impl PhotoStore for FileSystemPhotoStore {
     async fn delete_data(&self, photo_id: Uuid) -> PhotoStoreResult<()> {
         debug!("Deleting data for photo: {}", photo_id);
 
-        // Get photo metadata (if it exists)
         if let Some(photo) = self.photos.get(&photo_id) {
             let photo_clone = photo.value().clone();
-            drop(photo); // Release the lock
+            drop(photo);
 
             let catalog_id = self.resolve_catalog_id(photo_clone.task_id).await?;
             let file_path =
                 self.layout
                     .photo_file_path(catalog_id, photo_clone.task_id, photo_clone.photo_id);
-            if file_path.exists() {
-                if let Err(e) = tokio::fs::remove_file(&file_path).await {
-                    error!("Failed to remove photo file {:?}: {}", file_path, e);
-                    // Don't fail - best effort deletion
-                }
+            match tokio::fs::remove_file(&file_path).await {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => error!("Failed to remove photo file {:?}: {}", file_path, e),
             }
         }
         Ok(())
     }
 }
-
-// ============================================================================
-// Unit Tests
-// ============================================================================
 
 #[cfg(test)]
 mod tests {
@@ -538,14 +493,12 @@ mod tests {
     use chrono::Utc;
     use tempfile::TempDir;
 
-    // Helper struct to keep temp dir alive during test
     struct TestStore {
         store: FileSystemPhotoStore,
         task_store: Arc<dyn TaskStore>,
         _temp_dir: TempDir,
     }
 
-    // Helper function to create a fresh store with temp directory
     async fn create_store() -> TestStore {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let storage_path = temp_dir.path().to_path_buf();
@@ -574,7 +527,6 @@ mod tests {
         catalog_id
     }
 
-    // Helper function to create a test photo
     fn create_test_photo(task_id: Uuid, filename: &str, size_bytes: u64) -> Photo {
         Photo::new(task_id, None, filename.to_string(), size_bytes)
     }
@@ -594,11 +546,9 @@ mod tests {
         assert_eq!(created.task_id, photo.task_id);
         assert_eq!(created.filename, photo.filename);
 
-        // Verify it exists in the store
         let exists = ts.store.exists(photo.photo_id).await.unwrap();
         assert!(exists);
 
-        // Verify photos.json was created
         assert!(
             ts.store
                 .layout
@@ -614,10 +564,8 @@ mod tests {
         setup_task(&ts, task_id).await;
         let photo = create_test_photo(task_id, "test.jpg", 1_000_000);
 
-        // First creation should succeed
         ts.store.create(photo.clone()).await.unwrap();
 
-        // Second creation with same ID should fail
         let result = ts.store.create(photo.clone()).await;
 
         assert!(result.is_err());
@@ -665,7 +613,6 @@ mod tests {
         setup_task(&ts, task_a).await;
         setup_task(&ts, task_b).await;
 
-        // Create photos for two different tasks
         let photo1 = create_test_photo(task_a, "photo1.jpg", 1_000_000);
         let photo2 = create_test_photo(task_a, "photo2.jpg", 2_000_000);
         let photo3 = create_test_photo(task_b, "photo3.jpg", 3_000_000);
@@ -674,17 +621,14 @@ mod tests {
         ts.store.create(photo2.clone()).await.unwrap();
         ts.store.create(photo3.clone()).await.unwrap();
 
-        // List photos for task_A
         let photos_a = ts.store.list_by_task(task_a).await.unwrap();
         assert_eq!(photos_a.len(), 2);
         assert!(photos_a.iter().all(|p| p.task_id == task_a));
 
-        // List photos for task_B
         let photos_b = ts.store.list_by_task(task_b).await.unwrap();
         assert_eq!(photos_b.len(), 1);
         assert_eq!(photos_b[0].task_id, task_b);
 
-        // List photos for nonexistent task
         let photos_c = ts.store.list_by_task(Uuid::new_v4()).await.unwrap();
         assert!(photos_c.is_empty());
     }
@@ -697,7 +641,6 @@ mod tests {
         let photo = create_test_photo(task_id, "test.jpg", 1_000_000);
 
         ts.store.create(photo.clone()).await.unwrap();
-        // Save data so we can verify it's deleted too
         ts.store
             .save_data(photo.photo_id, &[1, 2, 3])
             .await
@@ -708,16 +651,13 @@ mod tests {
             .photo_file_path(catalog_id, photo.task_id, photo.photo_id);
         assert!(file_path.exists());
 
-        // Delete the photo
         let result = ts.store.delete(photo.photo_id).await;
 
         assert!(result.is_ok());
 
-        // Verify it no longer exists
         let retrieved = ts.store.get(photo.photo_id).await.unwrap();
         assert!(retrieved.is_none());
 
-        // Verify file was removed
         assert!(!file_path.exists());
     }
 
@@ -754,15 +694,12 @@ mod tests {
         ts.store.create(photo2).await.unwrap();
         ts.store.create(photo3.clone()).await.unwrap();
 
-        // Delete all photos for task_A
         let deleted = ts.store.delete_by_task(task_a).await.unwrap();
         assert_eq!(deleted, 2);
 
-        // Verify task_A photos are gone
         let photos_a = ts.store.list_by_task(task_a).await.unwrap();
         assert!(photos_a.is_empty());
 
-        // Verify task_B photo still exists
         let photos_b = ts.store.list_by_task(task_b).await.unwrap();
         assert_eq!(photos_b.len(), 1);
     }
@@ -775,11 +712,9 @@ mod tests {
         setup_task(&ts, task_a).await;
         setup_task(&ts, task_b).await;
 
-        // Empty task should have count 0
         let count = ts.store.count_by_task(task_a).await.unwrap();
         assert_eq!(count, 0);
 
-        // Add photos
         let photo1 = create_test_photo(task_a, "photo1.jpg", 1_000_000);
         let photo2 = create_test_photo(task_a, "photo2.jpg", 2_000_000);
         let photo3 = create_test_photo(task_b, "photo3.jpg", 3_000_000);
@@ -788,11 +723,9 @@ mod tests {
         ts.store.create(photo2).await.unwrap();
         ts.store.create(photo3).await.unwrap();
 
-        // Count for task_A
         let count = ts.store.count_by_task(task_a).await.unwrap();
         assert_eq!(count, 2);
 
-        // Count for task_B
         let count = ts.store.count_by_task(task_b).await.unwrap();
         assert_eq!(count, 1);
     }
@@ -805,11 +738,9 @@ mod tests {
         setup_task(&ts, task_a).await;
         setup_task(&ts, task_b).await;
 
-        // Empty task should have size 0
         let size = ts.store.total_size_by_task(task_a).await.unwrap();
         assert_eq!(size, 0);
 
-        // Add photos with known sizes
         let photo1 = create_test_photo(task_a, "photo1.jpg", 1_000_000);
         let photo2 = create_test_photo(task_a, "photo2.jpg", 2_500_000);
         let photo3 = create_test_photo(task_b, "photo3.jpg", 3_000_000);
@@ -818,11 +749,9 @@ mod tests {
         ts.store.create(photo2).await.unwrap();
         ts.store.create(photo3).await.unwrap();
 
-        // Total size for task_A
         let size = ts.store.total_size_by_task(task_a).await.unwrap();
         assert_eq!(size, 3_500_000);
 
-        // Total size for task_B
         let size = ts.store.total_size_by_task(task_b).await.unwrap();
         assert_eq!(size, 3_000_000);
     }
@@ -834,25 +763,17 @@ mod tests {
         setup_task(&ts, task_id).await;
         let photo = create_test_photo(task_id, "test.jpg", 1_000_000);
 
-        // Should not exist initially
         let exists = ts.store.exists(photo.photo_id).await.unwrap();
         assert!(!exists);
 
-        // Create the photo
         ts.store.create(photo.clone()).await.unwrap();
 
-        // Should exist now
         let exists = ts.store.exists(photo.photo_id).await.unwrap();
         assert!(exists);
 
-        // Random ID should not exist
         let exists = ts.store.exists(Uuid::new_v4()).await.unwrap();
         assert!(!exists);
     }
-
-    // ========================================================================
-    // Binary Data Tests
-    // ========================================================================
 
     #[tokio::test]
     async fn test_save_and_load_data() {
@@ -861,24 +782,20 @@ mod tests {
         let catalog_id = setup_task(&ts, task_id).await;
         let photo = create_test_photo(task_id, "test.jpg", 1_000);
 
-        // Create the photo first
         ts.store.create(photo.clone()).await.unwrap();
 
-        // Save some data
         let test_data = vec![0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10];
         ts.store
             .save_data(photo.photo_id, &test_data)
             .await
             .unwrap();
 
-        // Verify file exists on disk
         let file_path = ts
             .store
             .layout
             .photo_file_path(catalog_id, photo.task_id, photo.photo_id);
         assert!(file_path.exists());
 
-        // Load the data back
         let loaded = ts.store.load_data(photo.photo_id).await.unwrap();
         assert_eq!(loaded, test_data);
     }
@@ -887,7 +804,6 @@ mod tests {
     async fn test_save_data_requires_photo_metadata() {
         let ts = create_store().await;
 
-        // Try to save data without creating photo metadata first
         let nonexistent_id = Uuid::new_v4();
         let test_data = vec![0xFF, 0xD8, 0xFF, 0xE0];
         let result = ts.store.save_data(nonexistent_id, &test_data).await;
@@ -906,10 +822,8 @@ mod tests {
         setup_task(&ts, task_id).await;
         let photo = create_test_photo(task_id, "test.jpg", 1_000);
 
-        // Create photo metadata but don't save data
         ts.store.create(photo.clone()).await.unwrap();
 
-        // Try to load data (file doesn't exist)
         let result = ts.store.load_data(photo.photo_id).await;
 
         assert!(result.is_err());
@@ -926,7 +840,6 @@ mod tests {
         setup_task(&ts, task_id).await;
         let photo = create_test_photo(task_id, "test.jpg", 1_000);
 
-        // Create photo and save data
         ts.store.create(photo.clone()).await.unwrap();
         let test_data = vec![0xFF, 0xD8, 0xFF, 0xE0];
         ts.store
@@ -934,10 +847,8 @@ mod tests {
             .await
             .unwrap();
 
-        // Delete the photo
         ts.store.delete(photo.photo_id).await.unwrap();
 
-        // Metadata should be gone, so load_data will fail with NotFound
         let result = ts.store.load_data(photo.photo_id).await;
         assert!(result.is_err());
     }
@@ -950,10 +861,6 @@ mod tests {
         let result = ts.store.delete_data(Uuid::new_v4()).await;
         assert!(result.is_ok());
     }
-
-    // ========================================================================
-    // Persistence Tests
-    // ========================================================================
 
     #[tokio::test]
     async fn test_persistence_survives_reload() {
@@ -984,12 +891,10 @@ mod tests {
             assert_eq!(store.count_by_task(task_id).await.unwrap(), 2);
         }
 
-        // Create new store instance (simulates server restart)
         let task_store: Arc<dyn TaskStore> =
             Arc::new(FileSystemTaskStore::new(storage_path.clone()).await);
         let store = FileSystemPhotoStore::new(storage_path, task_store).await;
 
-        // Photos should be loaded from filesystem
         assert_eq!(store.count_by_task(task_id).await.unwrap(), 2);
         assert!(store.exists(photo1_id).await.unwrap());
         assert!(store.exists(photo2_id).await.unwrap());
@@ -1024,7 +929,6 @@ mod tests {
             store.delete(photo_id).await.unwrap();
         }
 
-        // Reload and verify photo is gone
         let task_store: Arc<dyn TaskStore> =
             Arc::new(FileSystemTaskStore::new(storage_path.clone()).await);
         let store = FileSystemPhotoStore::new(storage_path, task_store).await;
@@ -1055,35 +959,26 @@ mod tests {
         let store = FileSystemPhotoStore::new(storage_path.clone(), task_store).await;
         store.create(photo).await.unwrap();
 
-        // Save photo data
         let test_data = vec![0xFF, 0xD8, 0xFF, 0xE0];
         store.save_data(photo_id, &test_data).await.unwrap();
 
-        // Verify the photo is stored in the catalog-scoped task directory
         let layout = FileSystemLayout::new(storage_path);
         let task_dir = layout.task_dir(catalog_id, task_id);
 
-        // Verify imgs/ subdirectory exists
         let imgs_dir = task_dir.join("imgs");
         assert!(imgs_dir.exists(), "imgs/ directory should exist");
         assert!(imgs_dir.is_dir(), "imgs/ should be a directory");
 
-        // Verify photo file is in imgs/ subdirectory
         let photo_file = imgs_dir.join(photo_id.to_string());
         assert!(photo_file.exists(), "Photo file should exist in imgs/");
         assert!(photo_file.is_file(), "Photo should be a file");
 
-        // Verify photo is NOT in task root directory
         let wrong_path = task_dir.join(photo_id.to_string());
         assert!(
             !wrong_path.exists(),
             "Photo should NOT be in task root directory"
         );
     }
-
-    // ========================================================================
-    // find_by_client_id Tests
-    // ========================================================================
 
     #[tokio::test]
     async fn test_find_by_client_id_returns_matching_photos() {

--- a/api/src/storage/filesystem_photo_store.rs
+++ b/api/src/storage/filesystem_photo_store.rs
@@ -8,6 +8,7 @@
 //! and binary image data is stored as individual files.
 
 use async_trait::async_trait;
+use chrono::Local;
 use dashmap::DashMap;
 use dashmap::mapref::entry::Entry;
 use std::path::{Path, PathBuf};
@@ -57,9 +58,21 @@ impl FileSystemPhotoStore {
     /// * `storage_path` - Base path for storing photo files
     /// * `task_store` - Reference to the task store for resolving task-to-catalog relationships
     pub async fn new(storage_path: PathBuf, task_store: Arc<dyn TaskStore>) -> Self {
+        Self::new_with_boot_ts(storage_path, task_store, Local::now().format("%Y%m%d_%H%M%S").to_string()).await
+    }
+
+    /// Creates a new filesystem-backed photo store with an explicit boot timestamp.
+    ///
+    /// Use this when multiple stores must share the same quarantine directory for
+    /// a single server boot.
+    pub async fn new_with_boot_ts(
+        storage_path: PathBuf,
+        task_store: Arc<dyn TaskStore>,
+        boot_ts: String,
+    ) -> Self {
         let store = Self {
             photos: Arc::new(DashMap::new()),
-            layout: FileSystemLayout::new(storage_path),
+            layout: FileSystemLayout::new_with_boot_ts(storage_path, boot_ts),
             task_store,
         };
         store.load_all().await;

--- a/api/src/storage/filesystem_task_store.rs
+++ b/api/src/storage/filesystem_task_store.rs
@@ -250,8 +250,10 @@ impl TaskStore for FileSystemTaskStore {
         };
 
         let task_dir = self.layout.task_dir(task.catalog_id, task.task_id);
-        if task_dir.exists() {
-            if let Err(e) = tokio::fs::remove_dir_all(&task_dir).await {
+        match tokio::fs::remove_dir_all(&task_dir).await {
+            Ok(()) => debug!("Removed task directory: {:?}", task_dir),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
                 error!("Failed to remove task directory {:?}: {}", task_dir, e);
                 self.tasks.insert(task_id, task);
                 return Err(TaskStoreError::StorageError(format!(
@@ -259,7 +261,6 @@ impl TaskStore for FileSystemTaskStore {
                     e
                 )));
             }
-            debug!("Removed task directory: {:?}", task_dir);
         }
 
         info!(

--- a/api/src/storage/filesystem_task_store.rs
+++ b/api/src/storage/filesystem_task_store.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 
 use crate::models::Task;
 
-use super::utils::parse_uuid_from_dir;
+use super::utils::{parse_uuid_from_dir, quarantine_move};
 use super::{FileSystemLayout, TaskStore, TaskStoreError, TaskStoreResult};
 
 fn sorted_tasks(iter: impl Iterator<Item = Task>) -> Vec<Task> {
@@ -98,12 +98,14 @@ impl FileSystemTaskStore {
     /// Loads all tasks for a single catalog from the filesystem.
     ///
     /// Returns the count of successfully loaded tasks and errors encountered.
+    /// Task directories with corrupt, inconsistent, or missing task.json are
+    /// moved to the boot-scoped quarantine directory.
     async fn load_catalog_tasks(&self, catalog_id: Uuid) -> (usize, usize) {
-        let task_files = match self.layout.scan_task_json_files(catalog_id).await {
-            Ok(files) => files,
+        let task_dirs = match self.layout.scan_task_dirs(catalog_id).await {
+            Ok(dirs) => dirs,
             Err(e) => {
                 warn!(
-                    "Failed to scan task files for catalog {}: {}",
+                    "Failed to scan task directories for catalog {}: {}",
                     catalog_id, e
                 );
                 return (0, 1);
@@ -113,17 +115,49 @@ impl FileSystemTaskStore {
         let mut loaded = 0;
         let mut errors = 0;
 
-        for task_json in task_files {
-            match self.load_task_from_file(&task_json).await {
-                Ok(task) => {
-                    self.tasks.insert(task.task_id, task);
-                    loaded += 1;
+        for task_dir in task_dirs {
+            let task_json = task_dir.join("task.json");
+
+            if !task_json.exists() {
+                warn!("Orphan task directory (no task.json): {:?}", task_dir);
+                if let Err(e) = quarantine_move(&self.layout, &task_dir).await {
+                    error!("Failed to quarantine orphan task directory {:?}: {}", task_dir, e);
                 }
+                errors += 1;
+                continue;
+            }
+
+            let task = match self.load_task_from_file(&task_json).await {
+                Ok(t) => t,
                 Err(e) => {
-                    warn!("Failed to load task from {:?}: {}", task_json, e);
+                    error!(
+                        "Corrupt task.json in {:?}: {} — quarantining task directory",
+                        task_dir, e
+                    );
+                    if let Err(qe) = quarantine_move(&self.layout, &task_dir).await {
+                        error!("Failed to quarantine {:?}: {}", task_dir, qe);
+                    }
                     errors += 1;
+                    continue;
+                }
+            };
+
+            if let Some(dir_id) = parse_uuid_from_dir(&task_dir) {
+                if dir_id != task.task_id {
+                    error!(
+                        "Inconsistent task.json in {:?}: task_id {} does not match directory {} — quarantining",
+                        task_dir, task.task_id, dir_id
+                    );
+                    if let Err(qe) = quarantine_move(&self.layout, &task_dir).await {
+                        error!("Failed to quarantine {:?}: {}", task_dir, qe);
+                    }
+                    errors += 1;
+                    continue;
                 }
             }
+
+            self.tasks.insert(task.task_id, task);
+            loaded += 1;
         }
 
         (loaded, errors)
@@ -764,5 +798,103 @@ mod tests {
         let store = FileSystemTaskStore::new(storage_path).await;
         assert_eq!(store.count().await.unwrap(), 0);
         assert!(!store.exists(task_id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_load_quarantines_corrupt_task_json() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let storage_path = temp_dir.path().to_path_buf();
+
+        let catalog_id = Uuid::new_v4();
+        let task_id = Uuid::new_v4();
+        let task_dir = storage_path
+            .join("catalogs")
+            .join(catalog_id.to_string())
+            .join("tasks")
+            .join(task_id.to_string());
+        tokio::fs::create_dir_all(&task_dir).await.unwrap();
+        tokio::fs::write(task_dir.join("task.json"), b"not valid json")
+            .await
+            .unwrap();
+
+        let store = FileSystemTaskStore::new(storage_path).await;
+
+        assert_eq!(store.count().await.unwrap(), 0);
+        assert!(!task_dir.exists());
+        assert!(store.layout.quarantine_path_for(&task_dir).exists());
+    }
+
+    #[tokio::test]
+    async fn test_load_quarantines_inconsistent_task_id() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let storage_path = temp_dir.path().to_path_buf();
+
+        let catalog_id = Uuid::new_v4();
+        let dir_task_id = Uuid::new_v4();
+        let json_task_id = Uuid::new_v4();
+
+        let task_dir = storage_path
+            .join("catalogs")
+            .join(catalog_id.to_string())
+            .join("tasks")
+            .join(dir_task_id.to_string());
+        tokio::fs::create_dir_all(&task_dir).await.unwrap();
+
+        let task = Task {
+            task_id: json_task_id,
+            catalog_id,
+            name: "test".to_string(),
+            context: "ctx".to_string(),
+            created_at: Utc::now(),
+        };
+        tokio::fs::write(task_dir.join("task.json"), serde_json::to_string(&task).unwrap())
+            .await
+            .unwrap();
+
+        let store = FileSystemTaskStore::new(storage_path).await;
+
+        assert_eq!(store.count().await.unwrap(), 0);
+        assert!(!task_dir.exists());
+        assert!(store.layout.quarantine_path_for(&task_dir).exists());
+    }
+
+    #[tokio::test]
+    async fn test_load_quarantines_orphan_task_dir() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let storage_path = temp_dir.path().to_path_buf();
+
+        let catalog_id = Uuid::new_v4();
+        let task_id = Uuid::new_v4();
+        let task_dir = storage_path
+            .join("catalogs")
+            .join(catalog_id.to_string())
+            .join("tasks")
+            .join(task_id.to_string());
+        tokio::fs::create_dir_all(&task_dir).await.unwrap();
+
+        let store = FileSystemTaskStore::new(storage_path).await;
+
+        assert_eq!(store.count().await.unwrap(), 0);
+        assert!(!task_dir.exists());
+        assert!(store.layout.quarantine_path_for(&task_dir).exists());
+    }
+
+    #[tokio::test]
+    async fn test_load_valid_task_not_quarantined() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let storage_path = temp_dir.path().to_path_buf();
+
+        let task = create_test_task("valid task");
+
+        {
+            let store = FileSystemTaskStore::new(storage_path.clone()).await;
+            store.create(task.clone()).await.unwrap();
+        }
+
+        let store = FileSystemTaskStore::new(storage_path).await;
+
+        assert_eq!(store.count().await.unwrap(), 1);
+        assert!(store.exists(task.task_id).await.unwrap());
+        assert!(!store.layout.quarantine_dir().exists());
     }
 }

--- a/api/src/storage/filesystem_task_store.rs
+++ b/api/src/storage/filesystem_task_store.rs
@@ -9,7 +9,7 @@
 use async_trait::async_trait;
 use dashmap::DashMap;
 use dashmap::mapref::entry::Entry;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
@@ -18,9 +18,17 @@ use crate::models::Task;
 
 use super::{FileSystemLayout, TaskStore, TaskStoreError, TaskStoreResult};
 
-// ============================================================================
-// FileSystemTaskStore Implementation
-// ============================================================================
+fn parse_uuid_from_dir(path: &Path) -> Option<Uuid> {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .and_then(|s| s.parse().ok())
+}
+
+fn sorted_tasks(iter: impl Iterator<Item = Task>) -> Vec<Task> {
+    let mut tasks: Vec<Task> = iter.collect();
+    tasks.sort_by_key(|t| t.created_at);
+    tasks
+}
 
 /// Filesystem-backed implementation of TaskStore with full persistence.
 ///
@@ -76,65 +84,58 @@ impl FileSystemTaskStore {
             }
         };
 
-        let mut loaded_count = 0;
-        let mut error_count = 0;
+        let mut loaded = 0;
+        let mut errors = 0;
 
         for catalog_dir in catalog_dirs {
-            let catalog_id = match catalog_dir
-                .file_name()
-                .and_then(|n| n.to_str())
-                .and_then(|s| s.parse::<Uuid>().ok())
-            {
-                Some(id) => id,
-                None => {
-                    warn!("Skipping invalid catalog directory: {:?}", catalog_dir);
-                    continue;
-                }
+            let Some(catalog_id) = parse_uuid_from_dir(&catalog_dir) else {
+                warn!("Skipping invalid catalog directory: {:?}", catalog_dir);
+                continue;
             };
+            let (n_loaded, n_errors) = self.load_catalog_tasks(catalog_id).await;
+            loaded += n_loaded;
+            errors += n_errors;
+        }
 
-            let task_files = match self.layout.scan_task_json_files(catalog_id).await {
-                Ok(files) => files,
+        info!("Loaded {} tasks from filesystem ({} errors)", loaded, errors);
+    }
+
+    /// Loads all tasks for a single catalog from the filesystem.
+    ///
+    /// Returns the count of successfully loaded tasks and errors encountered.
+    async fn load_catalog_tasks(&self, catalog_id: Uuid) -> (usize, usize) {
+        let task_files = match self.layout.scan_task_json_files(catalog_id).await {
+            Ok(files) => files,
+            Err(e) => {
+                warn!(
+                    "Failed to scan task files for catalog {}: {}",
+                    catalog_id, e
+                );
+                return (0, 1);
+            }
+        };
+
+        let mut loaded = 0;
+        let mut errors = 0;
+
+        for task_json in task_files {
+            match self.load_task_from_file(&task_json).await {
+                Ok(task) => {
+                    self.tasks.insert(task.task_id, task);
+                    loaded += 1;
+                }
                 Err(e) => {
-                    warn!(
-                        "Failed to scan task files for catalog {}: {}",
-                        catalog_id, e
-                    );
-                    error_count += 1;
-                    continue;
-                }
-            };
-
-            for task_json in task_files {
-                match self.load_task_from_file(&task_json).await {
-                    Ok(mut task) => {
-                        if task.name.is_empty() {
-                            task.ensure_name();
-                            if let Err(e) = self.save_task_to_file(&task).await {
-                                warn!(
-                                    "Failed to persist migrated name for task {}: {}",
-                                    task.task_id, e
-                                );
-                            }
-                        }
-                        self.tasks.insert(task.task_id, task);
-                        loaded_count += 1;
-                    }
-                    Err(e) => {
-                        warn!("Failed to load task from {:?}: {}", task_json, e);
-                        error_count += 1;
-                    }
+                    warn!("Failed to load task from {:?}: {}", task_json, e);
+                    errors += 1;
                 }
             }
         }
 
-        info!(
-            "Loaded {} tasks from filesystem ({} errors)",
-            loaded_count, error_count
-        );
+        (loaded, errors)
     }
 
     /// Loads a single task from a JSON file.
-    async fn load_task_from_file(&self, path: &PathBuf) -> TaskStoreResult<Task> {
+    async fn load_task_from_file(&self, path: &Path) -> TaskStoreResult<Task> {
         let content = tokio::fs::read_to_string(path).await.map_err(|e| {
             TaskStoreError::StorageError(format!("Failed to read task file: {}", e))
         })?;
@@ -169,10 +170,6 @@ impl FileSystemTaskStore {
     }
 }
 
-// ============================================================================
-// TaskStore Trait Implementation
-// ============================================================================
-
 #[async_trait]
 impl TaskStore for FileSystemTaskStore {
     async fn create(&self, task: Task) -> TaskStoreResult<Task> {
@@ -180,11 +177,9 @@ impl TaskStore for FileSystemTaskStore {
 
         debug!("Attempting to create task: {}", task_id);
 
-        // Use entry API to atomically check and insert
         match self.tasks.entry(task_id) {
             Entry::Occupied(_) => Err(TaskStoreError::AlreadyExists(task_id)),
             Entry::Vacant(entry) => {
-                // Create task directory on filesystem
                 let task_dir = self
                     .layout
                     .ensure_task_dir(task.catalog_id, task.task_id)
@@ -198,7 +193,6 @@ impl TaskStore for FileSystemTaskStore {
                     })?;
                 debug!("Created task directory: {:?}", task_dir);
 
-                // Save metadata to filesystem
                 self.save_task_to_file(&task).await?;
 
                 entry.insert(task.clone());
@@ -214,22 +208,13 @@ impl TaskStore for FileSystemTaskStore {
     async fn get(&self, task_id: Uuid) -> TaskStoreResult<Option<Task>> {
         debug!("Retrieving task: {}", task_id);
 
-        // Lock-free read with DashMap
         Ok(self.tasks.get(&task_id).map(|entry| entry.value().clone()))
     }
 
     async fn list(&self) -> TaskStoreResult<Vec<Task>> {
         debug!("Listing all tasks");
 
-        // Collect all tasks into a vector
-        let mut tasks: Vec<Task> = self
-            .tasks
-            .iter()
-            .map(|entry| entry.value().clone())
-            .collect();
-
-        // Sort by created_at (oldest first) for deterministic output
-        tasks.sort_by_key(|task| task.created_at);
+        let tasks = sorted_tasks(self.tasks.iter().map(|e| e.value().clone()));
 
         info!("Listed {} tasks", tasks.len());
         Ok(tasks)
@@ -287,28 +272,24 @@ impl TaskStore for FileSystemTaskStore {
     async fn exists(&self, task_id: Uuid) -> TaskStoreResult<bool> {
         debug!("Checking if task exists: {}", task_id);
 
-        // Lock-free existence check
         Ok(self.tasks.contains_key(&task_id))
     }
 
     async fn count(&self) -> TaskStoreResult<usize> {
         debug!("Counting tasks");
 
-        // O(1) operation using internal atomic counter
         Ok(self.tasks.len())
     }
 
     async fn list_by_catalog(&self, catalog_id: Uuid) -> TaskStoreResult<Vec<Task>> {
         debug!("Listing tasks for catalog: {}", catalog_id);
 
-        let mut tasks: Vec<Task> = self
-            .tasks
-            .iter()
-            .filter(|entry| entry.value().catalog_id == catalog_id)
-            .map(|entry| entry.value().clone())
-            .collect();
-
-        tasks.sort_by_key(|task| task.created_at);
+        let tasks = sorted_tasks(
+            self.tasks
+                .iter()
+                .filter(|e| e.value().catalog_id == catalog_id)
+                .map(|e| e.value().clone()),
+        );
 
         info!("Listed {} tasks for catalog {}", tasks.len(), catalog_id);
         Ok(tasks)
@@ -325,10 +306,6 @@ impl TaskStore for FileSystemTaskStore {
     }
 }
 
-// ============================================================================
-// Unit Tests
-// ============================================================================
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -336,13 +313,11 @@ mod tests {
     use tempfile::TempDir;
     use uuid::Uuid;
 
-    // Helper struct to keep temp dir alive during test
     struct TestStore {
         store: FileSystemTaskStore,
         _temp_dir: TempDir,
     }
 
-    // Helper function to create a fresh store with temp directory
     async fn create_store() -> TestStore {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let store = FileSystemTaskStore::new(temp_dir.path().to_path_buf()).await;
@@ -352,7 +327,6 @@ mod tests {
         }
     }
 
-    // Helper function to create a test task with specific timestamp
     fn create_test_task_with_timestamp(name: &str, timestamp: DateTime<Utc>) -> Task {
         Task {
             task_id: Uuid::new_v4(),
@@ -363,7 +337,6 @@ mod tests {
         }
     }
 
-    // Helper function to create a test task with current timestamp
     fn create_test_task(name: &str) -> Task {
         Task::new(
             Uuid::new_v4(),
@@ -384,11 +357,9 @@ mod tests {
         assert_eq!(created.task_id, task.task_id);
         assert_eq!(created.context, task.context);
 
-        // Verify it exists in the store
         let exists = ts.store.exists(task.task_id).await.unwrap();
         assert!(exists);
 
-        // Verify directory was created
         assert!(
             ts.store
                 .layout
@@ -396,7 +367,6 @@ mod tests {
                 .exists()
         );
 
-        // Verify task.json was created
         assert!(
             ts.store
                 .layout
@@ -410,10 +380,8 @@ mod tests {
         let ts = create_store().await;
         let task = create_test_task("vacation in SF");
 
-        // First creation should succeed
         ts.store.create(task.clone()).await.unwrap();
 
-        // Second creation with same ID should fail
         let result = ts.store.create(task.clone()).await;
 
         assert!(result.is_err());
@@ -454,18 +422,15 @@ mod tests {
     async fn test_list_tasks_ordered_by_created_at() {
         let ts = create_store().await;
 
-        // Create tasks with explicit timestamps to control ordering
         let now = Utc::now();
         let task1 = create_test_task_with_timestamp("First", now);
         let task2 = create_test_task_with_timestamp("Second", now + Duration::seconds(1));
         let task3 = create_test_task_with_timestamp("Third", now + Duration::seconds(2));
 
-        // Insert in random order
         ts.store.create(task2.clone()).await.unwrap();
         ts.store.create(task1.clone()).await.unwrap();
         ts.store.create(task3.clone()).await.unwrap();
 
-        // List should return ordered by created_at (oldest first)
         let tasks = ts.store.list().await.unwrap();
 
         assert_eq!(tasks.len(), 3);
@@ -484,7 +449,6 @@ mod tests {
 
         ts.store.create(task.clone()).await.unwrap();
 
-        // Update the context
         let mut updated_task = task.clone();
         updated_task.context = "Updated context".to_string();
 
@@ -494,7 +458,6 @@ mod tests {
         let updated = result.unwrap();
         assert_eq!(updated.context, "Updated context");
 
-        // Verify the change persisted
         let retrieved = ts.store.get(task.task_id).await.unwrap().unwrap();
         assert_eq!(retrieved.context, "Updated context");
     }
@@ -504,7 +467,6 @@ mod tests {
         let ts = create_store().await;
         let task = create_test_task("vacation in SF");
 
-        // Try to update without creating first
         let result = ts.store.update(task.clone()).await;
 
         assert!(result.is_err());
@@ -525,16 +487,13 @@ mod tests {
         let task_dir = ts.store.layout.task_dir(task.catalog_id, task.task_id);
         assert!(task_dir.exists());
 
-        // Delete the task
         let result = ts.store.delete(task.task_id).await;
 
         assert!(result.is_ok());
 
-        // Verify it no longer exists
         let retrieved = ts.store.get(task.task_id).await.unwrap();
         assert!(retrieved.is_none());
 
-        // Verify directory was removed
         assert!(!task_dir.exists());
     }
 
@@ -559,18 +518,14 @@ mod tests {
         let ts = create_store().await;
         let task = create_test_task("vacation in SF");
 
-        // Should not exist initially
         let exists = ts.store.exists(task.task_id).await.unwrap();
         assert!(!exists);
 
-        // Create the task
         ts.store.create(task.clone()).await.unwrap();
 
-        // Should exist now
         let exists = ts.store.exists(task.task_id).await.unwrap();
         assert!(exists);
 
-        // Random ID should not exist
         let exists = ts.store.exists(Uuid::new_v4()).await.unwrap();
         assert!(!exists);
     }
@@ -579,11 +534,9 @@ mod tests {
     async fn test_count() {
         let ts = create_store().await;
 
-        // Empty store should have count 0
         let count = ts.store.count().await.unwrap();
         assert_eq!(count, 0);
 
-        // Add 3 tasks
         let task1 = create_test_task("First");
         let task2 = create_test_task("Second");
         let task3 = create_test_task("Third");
@@ -592,28 +545,20 @@ mod tests {
         ts.store.create(task2.clone()).await.unwrap();
         ts.store.create(task3.clone()).await.unwrap();
 
-        // Should have count 3
         let count = ts.store.count().await.unwrap();
         assert_eq!(count, 3);
 
-        // Delete one task
         ts.store.delete(task1.task_id).await.unwrap();
 
-        // Should have count 2
         let count = ts.store.count().await.unwrap();
         assert_eq!(count, 2);
     }
-
-    // ========================================================================
-    // Persistence Tests
-    // ========================================================================
 
     #[tokio::test]
     async fn test_persistence_survives_reload() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let storage_path = temp_dir.path().to_path_buf();
 
-        // Create store and add tasks
         let task1 = create_test_task("First task");
         let task2 = create_test_task("Second task");
         let task1_id = task1.task_id;
@@ -626,10 +571,8 @@ mod tests {
             assert_eq!(store.count().await.unwrap(), 2);
         }
 
-        // Create new store instance (simulates server restart)
         let store = FileSystemTaskStore::new(storage_path).await;
 
-        // Tasks should be loaded from filesystem
         assert_eq!(store.count().await.unwrap(), 2);
         assert!(store.exists(task1_id).await.unwrap());
         assert!(store.exists(task2_id).await.unwrap());
@@ -650,21 +593,15 @@ mod tests {
             let store = FileSystemTaskStore::new(storage_path.clone()).await;
             store.create(task.clone()).await.unwrap();
 
-            // Update the task
             let mut updated = task.clone();
             updated.context = "Updated context".to_string();
             store.update(updated).await.unwrap();
         }
 
-        // Reload and verify update persisted
         let store = FileSystemTaskStore::new(storage_path).await;
         let loaded = store.get(task_id).await.unwrap().unwrap();
         assert_eq!(loaded.context, "Updated context");
     }
-
-    // ========================================================================
-    // Resilience Tests
-    // ========================================================================
 
     /// Simulates a filesystem failure during delete by making the task directory
     /// non-removable, then verifies the task is rolled back into memory.
@@ -738,10 +675,6 @@ mod tests {
         let in_memory = ts.store.get(task.task_id).await.unwrap().unwrap();
         assert_eq!(in_memory.context, task.context);
     }
-
-    // ========================================================================
-    // Catalog-scoped Tests
-    // ========================================================================
 
     #[tokio::test]
     async fn test_list_by_catalog_returns_only_matching_tasks() {
@@ -818,10 +751,6 @@ mod tests {
         assert!(result.is_none());
     }
 
-    // ========================================================================
-    // Persistence Tests
-    // ========================================================================
-
     #[tokio::test]
     async fn test_delete_removes_from_filesystem() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
@@ -836,7 +765,6 @@ mod tests {
             store.delete(task_id).await.unwrap();
         }
 
-        // Reload and verify task is gone
         let store = FileSystemTaskStore::new(storage_path).await;
         assert_eq!(store.count().await.unwrap(), 0);
         assert!(!store.exists(task_id).await.unwrap());

--- a/api/src/storage/filesystem_task_store.rs
+++ b/api/src/storage/filesystem_task_store.rs
@@ -7,6 +7,7 @@
 //! with full persistence to the filesystem. Task metadata is stored as JSON files.
 
 use async_trait::async_trait;
+use chrono::Local;
 use dashmap::DashMap;
 use dashmap::mapref::entry::Entry;
 use std::path::{Path, PathBuf};
@@ -59,9 +60,17 @@ impl FileSystemTaskStore {
     /// # Arguments
     /// * `storage_path` - Base path for storing task directories
     pub async fn new(storage_path: PathBuf) -> Self {
+        Self::new_with_boot_ts(storage_path, Local::now().format("%Y%m%d_%H%M%S").to_string()).await
+    }
+
+    /// Creates a new filesystem-backed task store with an explicit boot timestamp.
+    ///
+    /// Use this when multiple stores must share the same quarantine directory for
+    /// a single server boot.
+    pub async fn new_with_boot_ts(storage_path: PathBuf, boot_ts: String) -> Self {
         let store = Self {
             tasks: Arc::new(DashMap::new()),
-            layout: FileSystemLayout::new(storage_path),
+            layout: FileSystemLayout::new_with_boot_ts(storage_path, boot_ts),
         };
         store.load_all().await;
         store

--- a/api/src/storage/filesystem_task_store.rs
+++ b/api/src/storage/filesystem_task_store.rs
@@ -16,13 +16,8 @@ use uuid::Uuid;
 
 use crate::models::Task;
 
+use super::utils::parse_uuid_from_dir;
 use super::{FileSystemLayout, TaskStore, TaskStoreError, TaskStoreResult};
-
-fn parse_uuid_from_dir(path: &Path) -> Option<Uuid> {
-    path.file_name()
-        .and_then(|n| n.to_str())
-        .and_then(|s| s.parse().ok())
-}
 
 fn sorted_tasks(iter: impl Iterator<Item = Task>) -> Vec<Task> {
     let mut tasks: Vec<Task> = iter.collect();

--- a/api/src/storage/filesystem_task_store.rs
+++ b/api/src/storage/filesystem_task_store.rs
@@ -10,6 +10,7 @@ use async_trait::async_trait;
 use chrono::Local;
 use dashmap::DashMap;
 use dashmap::mapref::entry::Entry;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};
@@ -17,7 +18,7 @@ use uuid::Uuid;
 
 use crate::models::Task;
 
-use super::utils::{parse_uuid_from_dir, quarantine_move};
+use super::utils::{load_json_from_file, parse_uuid_from_dir, try_quarantine, try_scan_task_dirs};
 use super::{FileSystemLayout, TaskStore, TaskStoreError, TaskStoreResult};
 
 fn sorted_tasks(iter: impl Iterator<Item = Task>) -> Vec<Task> {
@@ -110,59 +111,48 @@ impl FileSystemTaskStore {
     /// Task directories with corrupt, inconsistent, or missing task.json are
     /// moved to the boot-scoped quarantine directory.
     async fn load_catalog_tasks(&self, catalog_id: Uuid) -> (usize, usize) {
-        let task_dirs = match self.layout.scan_task_dirs(catalog_id).await {
-            Ok(dirs) => dirs,
-            Err(e) => {
-                warn!(
-                    "Failed to scan task directories for catalog {}: {}",
-                    catalog_id, e
-                );
-                return (0, 1);
-            }
+        let Some(task_dirs) = try_scan_task_dirs(&self.layout, catalog_id).await else {
+            return (0, 1);
         };
 
         let mut loaded = 0;
         let mut errors = 0;
 
         for task_dir in task_dirs {
+            let Some(dir_id) = parse_uuid_from_dir(&task_dir) else {
+                warn!("Skipping non-UUID task directory: {:?}", task_dir);
+                continue;
+            };
+
             let task_json = task_dir.join("task.json");
 
-            if !task_json.exists() {
-                warn!("Orphan task directory (no task.json): {:?}", task_dir);
-                if let Err(e) = quarantine_move(&self.layout, &task_dir).await {
-                    error!("Failed to quarantine orphan task directory {:?}: {}", task_dir, e);
-                }
-                errors += 1;
-                continue;
-            }
-
-            let task = match self.load_task_from_file(&task_json).await {
+            let task = match load_json_from_file::<Task>(&task_json).await {
                 Ok(t) => t,
+                Err(e) if e.kind() == ErrorKind::NotFound => {
+                    warn!("Orphan task directory (no task.json): {:?}", task_dir);
+                    try_quarantine(&self.layout, &task_dir).await;
+                    errors += 1;
+                    continue;
+                }
                 Err(e) => {
                     error!(
                         "Corrupt task.json in {:?}: {} — quarantining task directory",
                         task_dir, e
                     );
-                    if let Err(qe) = quarantine_move(&self.layout, &task_dir).await {
-                        error!("Failed to quarantine {:?}: {}", task_dir, qe);
-                    }
+                    try_quarantine(&self.layout, &task_dir).await;
                     errors += 1;
                     continue;
                 }
             };
 
-            if let Some(dir_id) = parse_uuid_from_dir(&task_dir) {
-                if dir_id != task.task_id {
-                    error!(
-                        "Inconsistent task.json in {:?}: task_id {} does not match directory {} — quarantining",
-                        task_dir, task.task_id, dir_id
-                    );
-                    if let Err(qe) = quarantine_move(&self.layout, &task_dir).await {
-                        error!("Failed to quarantine {:?}: {}", task_dir, qe);
-                    }
-                    errors += 1;
-                    continue;
-                }
+            if dir_id != task.task_id {
+                error!(
+                    "Inconsistent task.json in {:?}: task_id {} does not match directory {} — quarantining",
+                    task_dir, task.task_id, dir_id
+                );
+                try_quarantine(&self.layout, &task_dir).await;
+                errors += 1;
+                continue;
             }
 
             self.tasks.insert(task.task_id, task);
@@ -170,16 +160,6 @@ impl FileSystemTaskStore {
         }
 
         (loaded, errors)
-    }
-
-    /// Loads a single task from a JSON file.
-    async fn load_task_from_file(&self, path: &Path) -> TaskStoreResult<Task> {
-        let content = tokio::fs::read_to_string(path).await.map_err(|e| {
-            TaskStoreError::StorageError(format!("Failed to read task file: {}", e))
-        })?;
-
-        serde_json::from_str(&content)
-            .map_err(|e| TaskStoreError::StorageError(format!("Failed to parse task JSON: {}", e)))
     }
 
     /// Saves a task's metadata to the filesystem atomically.
@@ -290,7 +270,7 @@ impl TaskStore for FileSystemTaskStore {
         let task_dir = self.layout.task_dir(task.catalog_id, task.task_id);
         match tokio::fs::remove_dir_all(&task_dir).await {
             Ok(()) => debug!("Removed task directory: {:?}", task_dir),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) if e.kind() == ErrorKind::NotFound => {}
             Err(e) => {
                 error!("Failed to remove task directory {:?}: {}", task_dir, e);
                 self.tasks.insert(task_id, task);

--- a/api/src/storage/mod.rs
+++ b/api/src/storage/mod.rs
@@ -25,6 +25,7 @@ pub mod filesystem_task_store;
 pub mod job_store;
 pub mod photo_store;
 pub mod task_store;
+mod utils;
 
 // Re-export commonly used types
 pub use filesystem_job_store::FileSystemJobStore;

--- a/api/src/storage/utils.rs
+++ b/api/src/storage/utils.rs
@@ -33,3 +33,24 @@ pub(super) async fn quarantine_move(layout: &FileSystemLayout, path: &Path) -> i
     tokio::fs::rename(path, &dest).await?;
     Ok(dest)
 }
+
+/// Writes content to the boot-scoped quarantine path for a given file.
+///
+/// Unlike [`quarantine_move`], this does not remove the original file — it only
+/// creates a quarantine copy. Used for partial recovery (e.g., writing only the
+/// bad records extracted from a partially-corrupt file).
+/// Parent directories in the quarantine tree are created as needed.
+///
+/// Returns the quarantine path on success.
+pub(super) async fn quarantine_write(
+    layout: &FileSystemLayout,
+    original_path: &Path,
+    content: &[u8],
+) -> io::Result<PathBuf> {
+    let dest = layout.quarantine_path_for(original_path);
+    if let Some(parent) = dest.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    tokio::fs::write(&dest, content).await?;
+    Ok(dest)
+}

--- a/api/src/storage/utils.rs
+++ b/api/src/storage/utils.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 The Photometoria contributors
+
+//! Shared utilities for filesystem storage implementations
+
+use std::path::Path;
+use uuid::Uuid;
+
+/// Extracts a UUID from a directory path's last component.
+///
+/// Returns `None` if the directory name is missing or cannot be parsed as a UUID.
+pub(super) fn parse_uuid_from_dir(path: &Path) -> Option<Uuid> {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .and_then(|s| s.parse().ok())
+}

--- a/api/src/storage/utils.rs
+++ b/api/src/storage/utils.rs
@@ -5,9 +5,22 @@
 
 use std::io;
 use std::path::{Path, PathBuf};
+use tracing::{error, warn};
 use uuid::Uuid;
 
 use super::FileSystemLayout;
+
+/// Reads a JSON file from `path` and deserializes it into `T`.
+///
+/// - `io::ErrorKind::NotFound` is returned unchanged when the file does not exist.
+/// - Parse failures are returned as `io::ErrorKind::InvalidData`.
+pub(super) async fn load_json_from_file<T>(path: &Path) -> io::Result<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let content = tokio::fs::read_to_string(path).await?;
+    serde_json::from_str(&content).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}
 
 /// Extracts a UUID from a directory path's last component.
 ///
@@ -16,6 +29,31 @@ pub(super) fn parse_uuid_from_dir(path: &Path) -> Option<Uuid> {
     path.file_name()
         .and_then(|n| n.to_str())
         .and_then(|s| s.parse().ok())
+}
+
+/// Scans task subdirectories for a catalog, logging a warning and returning `None` on failure.
+pub(super) async fn try_scan_task_dirs(
+    layout: &FileSystemLayout,
+    catalog_id: Uuid,
+) -> Option<Vec<PathBuf>> {
+    match layout.scan_task_dirs(catalog_id).await {
+        Ok(dirs) => Some(dirs),
+        Err(e) => {
+            warn!("Failed to scan task directories for catalog {}: {}", catalog_id, e);
+            None
+        }
+    }
+}
+
+/// Moves a file or directory into the boot-scoped quarantine directory, logging
+/// any failure as an error.
+///
+/// Convenience wrapper around [`quarantine_move`] for use in load paths where
+/// quarantine failures must be logged but should not abort the overall scan.
+pub(super) async fn try_quarantine(layout: &FileSystemLayout, path: &Path) {
+    if let Err(e) = quarantine_move(layout, path).await {
+        error!("Failed to quarantine {:?}: {}", path, e);
+    }
 }
 
 /// Moves a file or directory into the boot-scoped quarantine directory.

--- a/api/src/storage/utils.rs
+++ b/api/src/storage/utils.rs
@@ -3,8 +3,11 @@
 
 //! Shared utilities for filesystem storage implementations
 
-use std::path::Path;
+use std::io;
+use std::path::{Path, PathBuf};
 use uuid::Uuid;
+
+use super::FileSystemLayout;
 
 /// Extracts a UUID from a directory path's last component.
 ///
@@ -13,4 +16,20 @@ pub(super) fn parse_uuid_from_dir(path: &Path) -> Option<Uuid> {
     path.file_name()
         .and_then(|n| n.to_str())
         .and_then(|s| s.parse().ok())
+}
+
+/// Moves a file or directory into the boot-scoped quarantine directory.
+///
+/// The destination mirrors the original path relative to the storage root, so
+/// the storage hierarchy is preserved inside the quarantine directory.
+/// Parent directories in the quarantine tree are created as needed.
+///
+/// Returns the quarantine path on success.
+pub(super) async fn quarantine_move(layout: &FileSystemLayout, path: &Path) -> io::Result<PathBuf> {
+    let dest = layout.quarantine_path_for(path);
+    if let Some(parent) = dest.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    tokio::fs::rename(path, &dest).await?;
+    Ok(dest)
 }


### PR DESCRIPTION
## Summary

Implements startup consistency checks for all filesystem-backed stores, as specified in #17.

- **Quarantine on corrupt/inconsistent data**: task directories, job files, and photos.json with invalid content are moved to a boot-scoped `quarantine/{timestamp}/` directory instead of being silently skipped
- **Partial recovery for photos**: valid photo records are preserved and rewritten; only bad records are quarantined
- **Orphan detection**: task directories without `task.json`, job files with mismatched IDs, and task directories with non-UUID names are all handled explicitly
- **Shared boot timestamp**: all three stores use the same quarantine directory per server boot

## Refactoring included

The implementation required significant refactoring of the filesystem store load paths:

- `load_json_from_file<T>`, `try_quarantine`, `try_scan_task_dirs` extracted to `utils.rs`
- `load_catalog_tasks` / `load_catalog_photos` / `load_catalog_jobs` replace the old `load_all` flat scan
- UUID guard checks moved to top of load loops; consistency checks are now unconditional
- TOCTOU `.exists()` check replaced with `ErrorKind::NotFound` match arm

## Test plan

- [x] 350 unit tests pass
- [x] Corrupt `task.json` → task directory quarantined
- [x] Inconsistent `task_id` in `task.json` vs directory name → quarantined
- [x] Orphan task directory (no `task.json`) → quarantined
- [x] Partially corrupt `photos.json` → bad records quarantined, good records preserved
- [x] Valid data survives reload without quarantine

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)