### PR TITLE
Remove deprecated GET /version and GET /api/models endpoints

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -6,17 +6,16 @@
 1. GET  /api/info                          → Server info and capabilities
 2. GET  /api/providers                     → List configured AI providers
 3. GET  /api/providers/{provider_name}     → Provider details and models
-4. GET  /api/models                        → List default provider models
-5. POST /api/catalogs/{catalog_id}/tasks   → Create task (working session)
+4. POST /api/catalogs/{catalog_id}/tasks   → Create task (working session)
    GET  /api/catalogs/{catalog_id}/tasks   → List tasks by catalog
-6. POST /api/tasks/{id}/photos             → Upload photos (multipart)
-7. POST /api/tasks/{id}/jobs               → Start job (choose AI model, optional language)
-8. GET  /api/tasks/{id}/jobs               → List jobs for a task
-9. [TODO #11] SSE streaming                → Monitor progress
-10. POST /api/jobs/{id}/cancel             → Cancel job (optional)
-11. GET /api/jobs/{id}/results             → Retrieve generated metadata
-12. POST /api/jobs/{id}/retry              → Retry failed/unprocessed photos
-13. DELETE /api/tasks/{id}                 → Cleanup
+5. POST /api/tasks/{id}/photos             → Upload photos (multipart)
+6. POST /api/tasks/{id}/jobs               → Start job (choose AI model, optional language)
+7. GET  /api/tasks/{id}/jobs               → List jobs for a task
+8. [TODO #11] SSE streaming                → Monitor progress
+9. POST /api/jobs/{id}/cancel              → Cancel job (optional)
+10. GET /api/jobs/{id}/results             → Retrieve generated metadata
+11. POST /api/jobs/{id}/retry              → Retry failed/unprocessed photos
+12. DELETE /api/tasks/{id}                 → Cleanup
 ```
 
 ---

--- a/api/docs/Photometoria.postman_collection.json
+++ b/api/docs/Photometoria.postman_collection.json
@@ -35,29 +35,6 @@
 	],
 	"item": [
 		{
-			"name": "Health",
-			"item": [
-				{
-					"name": "Get Version",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{base_url}}/version",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"version"
-							]
-						},
-						"description": "Returns the API version"
-					},
-					"response": []
-				}
-			]
-		},
-		{
 			"name": "Server Info",
 			"item": [
 				{
@@ -236,25 +213,6 @@
 						}
 					]
 				},
-				{
-					"name": "List Models (deprecated)",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{base_url}}/api/models",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"models"
-							]
-						},
-						"description": "**Deprecated:** use `GET /api/providers/{provider_name}` instead. Scheduled for removal in #32.\n\nReturns models for the default provider. The response format matches `GET /api/providers/{provider_name}`."
-					},
-					"response": []
-				}
 			]
 		},
 		{

--- a/api/docs/api-reference.md
+++ b/api/docs/api-reference.md
@@ -162,12 +162,6 @@ Returns details for a specific provider, including its configured models and the
 
 - `404` - Provider not found
 
-### GET /api/models *(deprecated)*
-
-> **Deprecated:** use `GET /api/providers/{provider_name}` instead. Scheduled for removal in #32.
-
-Returns models for the default provider. The response format matches `GET /api/providers/{provider_name}`.
-
 ## Task Endpoints
 
 ### POST /api/catalogs/{catalog_id}/tasks

--- a/api/docs/development.md
+++ b/api/docs/development.md
@@ -192,8 +192,7 @@ async fn test_create_job_invalid_photo_id() {
 **Location**: `src/routes/mod.rs`
 
 **Coverage**:
-- ✅ Smoke tests only (e.g., `/version` endpoint works)
-- ✅ Router configuration is valid
+- ✅ Smoke tests only (router configuration is valid)
 - ❌ Do NOT duplicate handler logic tests here
 
 **Rationale**: Handler tests cover business logic more cleanly without HTTP overhead.

--- a/api/src/handlers/providers.rs
+++ b/api/src/handlers/providers.rs
@@ -90,23 +90,6 @@ pub async fn provider_details(
     Ok(Json(provider_response(&provider, default_language).await))
 }
 
-/// Returns models for the default provider.
-///
-/// Deprecated in favour of [`provider_details`], which accepts an explicit
-/// provider name. Scheduled for removal in #32.
-#[deprecated]
-pub async fn list_default_provider_models(
-    State(state): State<AppState>,
-) -> Result<Json<ProviderDetailsResponse>, AppError> {
-    let provider = state
-        .ai_providers
-        .default_provider()
-        .map_err(|e| AppError::internal_error(e.to_string()))?;
-
-    let default_language = state.config.ai.default_language.clone();
-    Ok(Json(provider_response(&provider, default_language).await))
-}
-
 /// Builds a [`ProviderDetailsResponse`] for the given provider by cross-referencing
 /// configured models against those actually installed on the backend.
 async fn provider_response(

--- a/api/src/routes/mod.rs
+++ b/api/src/routes/mod.rs
@@ -8,7 +8,7 @@ use crate::handlers::jobs::{
     retry_job,
 };
 use crate::handlers::photos::{delete_photo, get_photo, task_photos};
-use crate::handlers::providers::{list_default_provider_models, list_providers, provider_details};
+use crate::handlers::providers::{list_providers, provider_details};
 use crate::handlers::tasks::{create_task, delete_task, get_task, list_tasks, update_task};
 use crate::handlers::upload_photos::upload_photos;
 use axum::{
@@ -25,7 +25,6 @@ pub fn create_router(state: AppState) -> Router {
         + 1024 * 1024; // 1MB overhead for multipart boundaries
 
     Router::new()
-        .route("/version", get(version))
         .route("/api/info", get(info))
         .route("/api/providers", get(list_providers))
         .route("/api/providers/{provider_name}", get(provider_details))
@@ -56,78 +55,6 @@ pub fn create_router(state: AppState) -> Router {
         .route("/api/jobs/{job_id}/results", get(get_job_results))
         .route("/api/jobs/{job_id}/cancel", post(cancel_job))
         .route("/api/jobs/{job_id}/retry", post(retry_job))
-        .route("/api/models", get(list_default_provider_models))
         .layer(TraceLayer::new_for_http())
         .with_state(state)
-}
-
-async fn version() -> &'static str {
-    env!("CARGO_PKG_VERSION")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::sync::Arc;
-
-    use axum::{body::Body, http::Request};
-    use http_body_util::BodyExt;
-    use tempfile::TempDir;
-    use tower::ServiceExt;
-
-    use crate::app_state::AppState;
-    use crate::config::Config;
-    use crate::services::ai::ProviderRegistry;
-    use crate::services::worker::WorkerPool;
-    use crate::storage::{
-        FileSystemJobStore, FileSystemPhotoStore, FileSystemTaskStore, PhotoStore, TaskStore,
-    };
-    use tokio::sync::Mutex;
-
-    struct TestApp {
-        router: Router,
-        state: AppState,
-        _temp_dir: TempDir,
-    }
-
-    async fn create_test_app() -> TestApp {
-        let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let storage_path = temp_dir.path().to_path_buf();
-        let config = Config::default();
-        let task_store: Arc<dyn TaskStore> =
-            Arc::new(FileSystemTaskStore::new(storage_path.clone()).await);
-        let photo_store: Arc<dyn PhotoStore> =
-            Arc::new(FileSystemPhotoStore::new(storage_path.clone(), task_store.clone()).await);
-        let job_store = Arc::new(FileSystemJobStore::new(storage_path, task_store.clone()).await);
-        let ai_providers = Arc::new(ProviderRegistry::new());
-        let worker_pool = Arc::new(Mutex::new(WorkerPool::new_inactive(job_store.clone())));
-        let state = AppState::new(
-            config,
-            task_store,
-            photo_store,
-            job_store,
-            ai_providers,
-            worker_pool,
-        );
-        let router = create_router(state.clone());
-        TestApp {
-            router,
-            state,
-            _temp_dir: temp_dir,
-        }
-    }
-
-    #[tokio::test]
-    async fn test_version_returns_package_version() {
-        let ta = create_test_app().await;
-        let request = Request::get("/version").body(Body::empty()).unwrap();
-        let response = ta.router.oneshot(request).await.unwrap();
-
-        assert_eq!(response.status(), 200);
-
-        let body = response.into_body().collect().await.unwrap().to_bytes();
-        let body_str = String::from_utf8(body.to_vec()).unwrap();
-
-        assert_eq!(body_str, env!("CARGO_PKG_VERSION"));
-    }
 }


### PR DESCRIPTION
## Summary

- Removes `GET /version` route and `version()` handler
- Removes `GET /api/models` route and `list_default_provider_models` handler
- Removes the now-empty router smoke test module
- Updates all affected documentation (api-reference, CLAUDE.md, development guide, Postman collection)

Closes #32

## Test plan

- [x] `cargo fmt && cargo clippy` — clean (no new warnings)
- [x] `cargo test` — 364 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)