### PR TITLE
Add num_ctx (context window) configuration for Ollama models

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -119,11 +119,21 @@ AppState         →  holds Arc<ProviderRegistry>
 
 ## AI Models (Ollama)
 
-- **qwen3.5:latest** — PRODUCTION (recommended, high quality)
-- **qwen3-vl:8b** — PRODUCTION (best vision quality, slower)
-- **ministral-3:latest** — Mistral vision model
-- **llava:latest** — DEVELOPMENT (faster, good for testing)
-- **gemma3n:e4b** — Google Gemma 3n vision model
+| Model | Status | Recommended `num_ctx` |
+|-------|--------|-----------------------|
+| **qwen3.5:latest** | PRODUCTION (recommended, high quality) | 8192 |
+| **qwen3-vl:8b** | PRODUCTION (best vision quality, slower) | 8192 |
+| **ministral-3:latest** | Mistral vision model | 4096 |
+| **llava:latest** | DEVELOPMENT (faster, good for testing) | 4096 |
+| **gemma3n:e4b** | Google Gemma 3n vision model | 4096 |
+
+Configure `num_ctx` per-model in TOML to avoid Ollama's default 2048-token context window being too small for vision prompts with task context:
+
+```toml
+[ai.providers.ollama.models.qwen3-vl]
+ollama_model = "qwen3-vl:8b"
+num_ctx = 8192
+```
 
 ---
 

--- a/api/config.toml.example
+++ b/api/config.toml.example
@@ -83,6 +83,10 @@ Example: {"tags": [{"tag": "sunset"}, {"tag": "mountain"}, {"tag": "landscape"},
 description = "Qwen 3.5 model: recommended for production"
 supports_vision = true
 supported_languages = ["English", "Italian", "French", "German", "Spanish"]
+# num_ctx sets the context window size in tokens forwarded to Ollama.
+# Increase this when processing images with long task context to avoid truncation.
+# When omitted, Ollama uses its own default (typically 2048 tokens).
+num_ctx = 8192
 
 [ai.providers.ollama.models.qwen3-vl]
 ollama_model = "qwen3-vl:8b"
@@ -95,6 +99,7 @@ Each object must have ONLY one key "tag" with a keyword string value.
 Example: {"tags": [{"tag": "sunset"}, {"tag": "mountain"}, {"tag": "landscape"}, {"tag": "golden light"}, {"tag": "outdoor"}]}"""
 description = "Best quality vision model, slower processing"
 supports_vision = true
+num_ctx = 8192
 
 [ai.providers.ollama.models.ministral-3]
 ollama_model = "ministral-3:latest"
@@ -107,6 +112,7 @@ Each object must have ONLY one key "tag" with a keyword string value.
 Example: {"tags": [{"tag": "sunset"}, {"tag": "mountain"}, {"tag": "landscape"}, {"tag": "golden light"}, {"tag": "outdoor"}]}"""
 description = "Mistral vision model"
 supports_vision = true
+num_ctx = 4096
 
 [ai.providers.ollama.models.llava]
 ollama_model = "llava:latest"
@@ -119,6 +125,7 @@ Each object must have ONLY one key "tag" with a keyword string value.
 Example: {"tags": [{"tag": "sunset"}, {"tag": "mountain"}, {"tag": "landscape"}, {"tag": "golden light"}, {"tag": "outdoor"}]}"""
 description = "Fast vision model, good for development"
 supports_vision = true
+num_ctx = 4096
 
 [ai.providers.ollama.models.gemma3n]
 ollama_model = "gemma3n:e4b"
@@ -131,6 +138,7 @@ Each object must have ONLY one key "tag" with a keyword string value.
 Example: {"tags": [{"tag": "sunset"}, {"tag": "mountain"}, {"tag": "landscape"}, {"tag": "golden light"}, {"tag": "outdoor"}]}"""
 description = "Google Gemma 3n vision model"
 supports_vision = true
+num_ctx = 4096
 
 # Worker Pool Configuration
 # -------------------------

--- a/api/src/config/ai.rs
+++ b/api/src/config/ai.rs
@@ -146,6 +146,11 @@ pub struct OllamaModelConfig {
     /// Languages this model has been tested or verified to support.
     #[serde(default)]
     pub supported_languages: Vec<String>,
+
+    /// Context window size in tokens. When set, forwarded to Ollama as
+    /// `options.num_ctx`. When absent, Ollama uses its own default.
+    #[serde(default)]
+    pub num_ctx: Option<u32>,
 }
 
 impl OllamaModelConfig {
@@ -268,5 +273,26 @@ mod tests {
         "#;
         let config: OllamaModelConfig = toml::from_str(toml).unwrap();
         assert!(config.supported_languages.is_empty());
+    }
+
+    #[test]
+    fn test_model_config_with_num_ctx() {
+        let toml = r#"
+            ollama_model = "qwen3-vl:8b"
+            supports_vision = true
+            num_ctx = 8192
+        "#;
+        let config: OllamaModelConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.num_ctx, Some(8192));
+    }
+
+    #[test]
+    fn test_model_config_without_num_ctx() {
+        let toml = r#"
+            ollama_model = "llava:latest"
+            supports_vision = true
+        "#;
+        let config: OllamaModelConfig = toml::from_str(toml).unwrap();
+        assert!(config.num_ctx.is_none());
     }
 }

--- a/api/src/services/ai/ollama/provider.rs
+++ b/api/src/services/ai/ollama/provider.rs
@@ -16,7 +16,9 @@ use super::super::error::{AIProviderError, AIProviderResult};
 use super::super::provider::{
     AIProvider, AnalyzeImageRequest, AnalyzeImageResponse, HealthStatus, ModelInfo, TokenUsage,
 };
-use super::types::{OllamaGenerateRequest, OllamaGenerateResponse, OllamaTagsResponse};
+use super::types::{
+    OllamaGenerateOptions, OllamaGenerateRequest, OllamaGenerateResponse, OllamaTagsResponse,
+};
 
 /// Ollama AI provider implementation.
 ///
@@ -89,6 +91,19 @@ impl OllamaProvider {
             .and_then(|config| config.prompt_template.as_ref())
             .cloned()
             .unwrap_or_else(|| default_prompt.to_string())
+    }
+
+    /// Builds generation options from the model config, or returns `None` if
+    /// no options are configured (so the request omits the field entirely).
+    fn get_options_for_model(&self, model_id: &str) -> Option<OllamaGenerateOptions> {
+        let config = self.configured_models.get(model_id)?;
+        if config.num_ctx.is_none() {
+            return None;
+        }
+        Some(OllamaGenerateOptions {
+            num_ctx: config.num_ctx,
+            ..Default::default()
+        })
     }
 }
 
@@ -254,7 +269,7 @@ impl AIProvider for OllamaProvider {
             prompt,
             images: Some(vec![request.image_base64]),
             stream: false,
-            options: None,
+            options: self.get_options_for_model(&request.model),
         };
 
         let url = self.api_url("/api/generate");
@@ -374,6 +389,7 @@ mod tests {
                 description: None,
                 supports_vision: true,
                 supported_languages: vec![],
+                num_ctx: None,
             },
         );
 
@@ -397,6 +413,7 @@ mod tests {
                 description: None,
                 supports_vision: true,
                 supported_languages: vec![],
+                num_ctx: None,
             },
         );
 
@@ -410,5 +427,54 @@ mod tests {
             provider.get_prompt_for_model("unknown", "default"),
             "default"
         );
+    }
+
+    #[test]
+    fn test_get_options_for_model_with_num_ctx() {
+        let mut models = HashMap::new();
+        models.insert(
+            "qwen3-vl".to_string(),
+            OllamaModelConfig {
+                ollama_model: "qwen3-vl:8b".to_string(),
+                prompt_template: None,
+                description: None,
+                supports_vision: true,
+                supported_languages: vec![],
+                num_ctx: Some(8192),
+            },
+        );
+
+        let provider = OllamaProvider::new("test", "http://localhost:11434", 30, models);
+
+        let options = provider.get_options_for_model("qwen3-vl").unwrap();
+        assert_eq!(options.num_ctx, Some(8192));
+        assert!(options.temperature.is_none());
+        assert!(options.num_predict.is_none());
+    }
+
+    #[test]
+    fn test_get_options_for_model_without_num_ctx() {
+        let mut models = HashMap::new();
+        models.insert(
+            "llava".to_string(),
+            OllamaModelConfig {
+                ollama_model: "llava:latest".to_string(),
+                prompt_template: None,
+                description: None,
+                supports_vision: true,
+                supported_languages: vec![],
+                num_ctx: None,
+            },
+        );
+
+        let provider = OllamaProvider::new("test", "http://localhost:11434", 30, models);
+
+        assert!(provider.get_options_for_model("llava").is_none());
+    }
+
+    #[test]
+    fn test_get_options_for_unknown_model() {
+        let provider = OllamaProvider::new("test", "http://localhost:11434", 30, HashMap::new());
+        assert!(provider.get_options_for_model("unknown").is_none());
     }
 }

--- a/api/src/services/ai/ollama/types.rs
+++ b/api/src/services/ai/ollama/types.rs
@@ -39,6 +39,10 @@ pub struct OllamaGenerateOptions {
     /// Maximum number of tokens to generate.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub num_predict: Option<i32>,
+
+    /// Context window size in tokens.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub num_ctx: Option<u32>,
 }
 
 /// Response from POST /api/generate (non-streaming).
@@ -196,5 +200,25 @@ mod tests {
         assert!(json.contains("\"model\":\"llava:latest\""));
         assert!(json.contains("\"stream\":false"));
         assert!(json.contains("\"images\":[\"base64data\"]"));
+        assert!(!json.contains("\"options\""));
+    }
+
+    #[test]
+    fn test_generate_options_num_ctx_serialized_when_set() {
+        let options = OllamaGenerateOptions {
+            num_ctx: Some(8192),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&options).unwrap();
+        assert!(json.contains("\"num_ctx\":8192"));
+        assert!(!json.contains("\"temperature\""));
+        assert!(!json.contains("\"num_predict\""));
+    }
+
+    #[test]
+    fn test_generate_options_num_ctx_omitted_when_none() {
+        let options = OllamaGenerateOptions::default();
+        let json = serde_json::to_string(&options).unwrap();
+        assert!(!json.contains("\"num_ctx\""));
     }
 }

--- a/api/src/services/ai/registry.rs
+++ b/api/src/services/ai/registry.rs
@@ -193,6 +193,7 @@ mod tests {
                 description: None,
                 supports_vision: true,
                 supported_languages: vec![],
+                num_ctx: None,
             },
         );
 

--- a/api/tests/ai_provider_tests.rs
+++ b/api/tests/ai_provider_tests.rs
@@ -23,6 +23,7 @@ fn create_test_provider(mock_server_uri: &str) -> OllamaProvider {
             description: Some("Test vision model".to_string()),
             supports_vision: true,
             supported_languages: vec![],
+            num_ctx: None,
         },
     );
 


### PR DESCRIPTION
Closes #105

## Summary

- Added `num_ctx: Option<u32>` to `OllamaModelConfig` (`config/ai.rs`) so each model can declare its required context window size in TOML
- Added `num_ctx: Option<u32>` to `OllamaGenerateOptions` (`ollama/types.rs`) with `skip_serializing_if = "Option::is_none"` so the field is omitted from requests when not set
- Added `get_options_for_model` helper in `OllamaProvider` that returns `None` when no options are configured, avoiding sending an `options` object at all
- `analyze_image` now populates `options` from model config instead of always passing `None`
- Updated `config.toml.example` with recommended `num_ctx` values for all five bundled models
- Updated `api/CLAUDE.md` model table with recommended values

## Test plan

- [ ] `cargo test` passes (376 tests)
- [ ] `num_ctx` serialized when `Some`, omitted when `None` (unit tests in `ollama/types.rs`)
- [ ] TOML parsed correctly with and without `num_ctx` (unit tests in `config/ai.rs`)
- [ ] `get_options_for_model` returns correct options or `None` (unit tests in `ollama/provider.rs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)