### PR TITLE
Show job timestamps and ETA in task dialog

### DIFF
--- a/api/docs/Photometoria.postman_collection.json
+++ b/api/docs/Photometoria.postman_collection.json
@@ -1489,7 +1489,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "[\n    {\n        \"job_id\": \"550e8400-e29b-41d4-a716-446655440010\",\n        \"status\": \"completed\",\n        \"model\": \"qwen3-vl\",\n        \"language\": \"English\",\n        \"photo_count\": 15,\n        \"queued_photo_count\": 0,\n        \"processed_photo_count\": 15,\n        \"created_at\": \"2024-01-15T10:35:00Z\",\n        \"completed_at\": \"2024-01-15T10:45:00Z\"\n    }\n]"
+                            "body": "[\n    {\n        \"job_id\": \"550e8400-e29b-41d4-a716-446655440010\",\n        \"status\": \"completed\",\n        \"model\": \"qwen3-vl\",\n        \"language\": \"English\",\n        \"photo_count\": 15,\n        \"queued_photo_count\": 0,\n        \"processed_photo_count\": 15,\n        \"created_at\": \"2024-01-15T10:35:00Z\",\n        \"started_at\": \"2024-01-15T10:35:10Z\",\n        \"completed_at\": \"2024-01-15T10:45:00Z\"\n    }\n]"
                         },
                         {
                             "name": "Task Not Found",
@@ -1565,7 +1565,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "[\n    {\n        \"job_id\": \"550e8400-e29b-41d4-a716-446655440010\",\n        \"status\": \"completed\",\n        \"model\": \"qwen3-vl\",\n        \"language\": \"English\",\n        \"photo_count\": 15,\n        \"queued_photo_count\": 0,\n        \"processed_photo_count\": 15,\n        \"created_at\": \"2024-01-15T10:35:00Z\",\n        \"completed_at\": \"2024-01-15T10:45:00Z\"\n    },\n    {\n        \"job_id\": \"550e8400-e29b-41d4-a716-446655440011\",\n        \"status\": \"queued\",\n        \"model\": \"llava\",\n        \"language\": \"Italian\",\n        \"photo_count\": 5,\n        \"queued_photo_count\": 5,\n        \"processed_photo_count\": 0,\n        \"created_at\": \"2024-01-15T11:00:00Z\"\n    }\n]"
+                            "body": "[\n    {\n        \"job_id\": \"550e8400-e29b-41d4-a716-446655440010\",\n        \"status\": \"completed\",\n        \"model\": \"qwen3-vl\",\n        \"language\": \"English\",\n        \"photo_count\": 15,\n        \"queued_photo_count\": 0,\n        \"processed_photo_count\": 15,\n        \"created_at\": \"2024-01-15T10:35:00Z\",\n        \"started_at\": \"2024-01-15T10:35:10Z\",\n        \"completed_at\": \"2024-01-15T10:45:00Z\"\n    },\n    {\n        \"job_id\": \"550e8400-e29b-41d4-a716-446655440011\",\n        \"status\": \"queued\",\n        \"model\": \"llava\",\n        \"language\": \"Italian\",\n        \"photo_count\": 5,\n        \"queued_photo_count\": 5,\n        \"processed_photo_count\": 0,\n        \"created_at\": \"2024-01-15T11:00:00Z\"\n    }\n]"
                         }
                     ]
                 },

--- a/api/docs/api-reference.md
+++ b/api/docs/api-reference.md
@@ -477,12 +477,13 @@ Returns a summary list of all jobs belonging to a specific task.
     "queued_photo_count": 0,
     "processed_photo_count": 15,
     "created_at": "2024-01-15T10:35:00Z",
+    "started_at": "2024-01-15T10:35:10Z",
     "completed_at": "2024-01-15T10:45:00Z"
   }
 ]
 ```
 
-`completed_at` is omitted when the job has not yet finished.
+`started_at` is omitted while the job is still `queued`. `completed_at` is omitted when the job has not yet finished.
 
 **Errors:**
 
@@ -594,12 +595,13 @@ Returns a summary list of all jobs across all tasks.
     "queued_photo_count": 0,
     "processed_photo_count": 15,
     "created_at": "2024-01-15T10:35:00Z",
+    "started_at": "2024-01-15T10:35:10Z",
     "completed_at": "2024-01-15T10:45:00Z"
   }
 ]
 ```
 
-`completed_at` is omitted when the job has not yet finished.
+`started_at` is omitted while the job is still `queued`. `completed_at` is omitted when the job has not yet finished.
 
 ### GET /api/jobs/{job_id}
 

--- a/api/src/handlers/jobs.rs
+++ b/api/src/handlers/jobs.rs
@@ -1445,6 +1445,38 @@ mod tests {
         assert_eq!(result.unwrap_err().body.error, "not_found");
     }
 
+    #[tokio::test]
+    async fn test_list_task_jobs_includes_started_at() {
+        let ts = create_test_state().await;
+
+        let task = Task::new(
+            test_catalog_id(),
+            "Task".to_string(),
+            "ctx".to_string(),
+        );
+        let task_id = task.task_id;
+        ts.state.task_store.create(task).await.unwrap();
+
+        let queued_job = Job::new(task_id, "llava".to_string(), None, vec![]);
+        let mut processing_job = Job::new(task_id, "llava".to_string(), None, vec![]);
+        processing_job.start();
+
+        ts.state.job_store.create(queued_job).await.unwrap();
+        ts.state.job_store.create(processing_job).await.unwrap();
+
+        let Json(jobs) = list_task_jobs(State(ts.state.clone()), AppPath(task_id))
+            .await
+            .unwrap();
+
+        assert_eq!(jobs.len(), 2);
+
+        let queued = jobs.iter().find(|j| j.status == JobStatus::Queued).unwrap();
+        let processing = jobs.iter().find(|j| j.status == JobStatus::Processing).unwrap();
+
+        assert!(queued.started_at.is_none());
+        assert!(processing.started_at.is_some());
+    }
+
     // ========================================================================
     // Tests for language support
     // ========================================================================

--- a/api/src/models/job.rs
+++ b/api/src/models/job.rs
@@ -395,6 +395,7 @@ pub struct JobResponse {
 ///   "model": "qwen3-vl:8b",
 ///   "photo_count": 15,
 ///   "created_at": "2024-01-15T10:35:00Z",
+///   "started_at": "2024-01-15T10:36:00Z",
 ///   "completed_at": "2024-01-15T10:45:00Z"
 /// }
 /// ```
@@ -427,6 +428,10 @@ pub struct JobSummary {
 
     /// Creation timestamp (ISO 8601)
     pub created_at: DateTime<Utc>,
+
+    /// Processing start timestamp (ISO 8601), None if not yet started
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<DateTime<Utc>>,
 
     /// Completion timestamp (ISO 8601), None if not finished
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -698,6 +703,7 @@ impl From<Job> for JobSummary {
             model: job.model.clone(),
             language: job.language.clone(),
             created_at: job.created_at,
+            started_at: job.started_at,
             completed_at: job.completed_at,
         }
     }
@@ -715,6 +721,7 @@ impl From<&Job> for JobSummary {
             model: job.model.clone(),
             language: job.language.clone(),
             created_at: job.created_at,
+            started_at: job.started_at,
             completed_at: job.completed_at,
         }
     }

--- a/plugin/photometoria.lrdevplugin/TaskDialogUI.lua
+++ b/plugin/photometoria.lrdevplugin/TaskDialogUI.lua
@@ -34,20 +34,44 @@ local function formatBytes(bytes)
 	end
 end
 
+--- Parses an ISO 8601 string into an LrDate timestamp (seconds since 2001-01-01 UTC).
+--- Returns nil if the string is absent or malformed.
+local function parseIsoTimestamp(isoString)
+	if not isoString or isoString == '' then
+		return nil
+	end
+	local y, mo, d, h, mi, s = isoString:match('(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+)')
+	if not y then
+		return nil
+	end
+	return LrDate.timeFromComponents(
+		tonumber(y), tonumber(mo), tonumber(d),
+		tonumber(h), tonumber(mi), tonumber(s), 'UTC'
+	)
+end
+
 --- Formats an ISO 8601 date string as a locale-friendly date and time.
 local function formatDateTime(isoString)
-	if not isoString or isoString == '' then
+	local time = parseIsoTimestamp(isoString)
+	if not time then
 		return ''
 	end
-	local y, m, d, h, min, s = isoString:match('(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+)')
-	if not y then
-		return ''
-	end
-	local time = LrDate.timeFromComponents(
-		tonumber(y), tonumber(m), tonumber(d),
-		tonumber(h), tonumber(min), tonumber(s), 'UTC'
-	)
 	return LrDate.formatMediumDate(time) .. ', ' .. LrDate.formatShortTime(time)
+end
+
+--- Formats a duration given in seconds as a human-readable string.
+local function formatDuration(seconds)
+	if seconds < 60 then
+		return string.format('%ds', math.floor(seconds))
+	elseif seconds < 3600 then
+		local m = math.floor(seconds / 60)
+		local s = math.floor(seconds % 60)
+		return string.format('%dm %ds', m, s)
+	else
+		local h = math.floor(seconds / 3600)
+		local m = math.floor((seconds % 3600) / 60)
+		return string.format('%dh %dm', h, m)
+	end
 end
 
 --- Reusable progress bar component for LrView.
@@ -250,6 +274,8 @@ local function clearJobDetail(props)
 	props.jobDetailVisible = false
 	props.jobSpinnerVisible = false
 	props.jobWaitingVisible = false
+	props.jobTimingLine1Visible = false
+	props.jobTimingLine2Visible = false
 	spinnerActive = false
 	props.btnApplyEnabled = false
 	props.btnRetryEnabled = false
@@ -290,6 +316,10 @@ local function initProperties(props, tasks)
 	props.jobSpinnerVisible = false
 	props.jobWaitingVisible = false
 	props.jobInfoText = ''
+	props.jobTimingLine1 = ''
+	props.jobTimingLine1Visible = false
+	props.jobTimingLine2 = ''
+	props.jobTimingLine2Visible = false
 	ProgressBar.init(props, 'jobDetail_pb')
 
 	props.btnApplyEnabled = false
@@ -359,6 +389,28 @@ local function onTaskSelected(props, tasks, index)
 	onJobSelected(props)
 end
 
+local ETA_MIN_PHOTOS = 2
+
+--- Computes estimated remaining seconds for a processing job.
+--- Returns nil when there is insufficient data for a reliable estimate.
+local function computeEtaSeconds(job)
+	local processed = job.processed_photo_count or 0
+	local total = job.photo_count or 0
+	if processed < ETA_MIN_PHOTOS or total <= processed then
+		return nil
+	end
+	local startTime = parseIsoTimestamp(job.started_at)
+	if not startTime then
+		return nil
+	end
+	local elapsed = LrDate.currentTime() - startTime
+	if elapsed <= 0 then
+		return nil
+	end
+	local rate = processed / elapsed
+	return (total - processed) / rate
+end
+
 --- Updates job detail panel when a job is selected.
 onJobSelected = function(props)
 	local selectedJob = props.selectedJobValue
@@ -382,6 +434,18 @@ onJobSelected = function(props)
 		local processed = job.processed_photo_count or 0
 		local total = job.photo_count or 0
 		ProgressBar.set(props, 'jobDetail_pb', processed, total)
+
+		props.jobTimingLine1 = LOC "$$$/Photometoria/Job/StartedAt=Started:" .. ' ' .. formatDateTime(job.started_at)
+		props.jobTimingLine1Visible = (job.started_at ~= nil and job.started_at ~= '')
+
+		local etaSeconds = computeEtaSeconds(job)
+		if etaSeconds then
+			props.jobTimingLine2 = LOC "$$$/Photometoria/Job/EstimatedRemaining=Est. remaining:" .. ' ~' .. formatDuration(etaSeconds)
+		else
+			props.jobTimingLine2 = LOC "$$$/Photometoria/Job/EtaCalculating=Calculating..."
+		end
+		props.jobTimingLine2Visible = true
+
 	elseif job.status == 'queued' then
 		props.jobProgressVisible = true
 		props.jobSpinnerVisible = false
@@ -391,6 +455,12 @@ onJobSelected = function(props)
 		local processed = job.processed_photo_count or 0
 		local total = job.photo_count or 0
 		ProgressBar.set(props, 'jobDetail_pb', processed, total)
+
+		props.jobTimingLine1 = LOC "$$$/Photometoria/Job/CreatedAt=Created:" .. ' ' .. formatDateTime(job.created_at)
+		props.jobTimingLine1Visible = true
+		props.jobTimingLine2 = ''
+		props.jobTimingLine2Visible = false
+
 	else
 		props.jobProgressVisible = false
 		props.jobSpinnerVisible = false
@@ -398,6 +468,31 @@ onJobSelected = function(props)
 		spinnerActive = false
 		props.jobInfoText = formatJobCompletedInfo(job)
 		ProgressBar.clear(props, 'jobDetail_pb')
+
+		props.jobTimingLine1 = LOC "$$$/Photometoria/Job/StartedAt=Started:" .. ' ' .. formatDateTime(job.started_at)
+		props.jobTimingLine1Visible = (job.started_at ~= nil and job.started_at ~= '')
+
+		if job.completed_at and job.completed_at ~= '' then
+			local endLabel
+			if job.status == 'failed' then
+				endLabel = LOC "$$$/Photometoria/Job/FailedAt=Failed:"
+			elseif job.status == 'cancelled' then
+				endLabel = LOC "$$$/Photometoria/Job/CancelledAt=Cancelled:"
+			else
+				endLabel = LOC "$$$/Photometoria/Job/CompletedAt=Completed:"
+			end
+			local durationStr = ''
+			local startTime = parseIsoTimestamp(job.started_at)
+			local endTime = parseIsoTimestamp(job.completed_at)
+			if startTime and endTime and endTime > startTime then
+				durationStr = ' (' .. formatDuration(endTime - startTime) .. ')'
+			end
+			props.jobTimingLine2 = endLabel .. ' ' .. formatDateTime(job.completed_at) .. durationStr
+			props.jobTimingLine2Visible = true
+		else
+			props.jobTimingLine2 = ''
+			props.jobTimingLine2Visible = false
+		end
 	end
 
 	props.btnApplyEnabled = (job.status == 'completed' or job.status == 'failed' or job.status == 'cancelled')
@@ -892,6 +987,22 @@ local function buildJobDetailPanel(f, props, host, tasks)
 		f:static_text {
 			title = bind 'jobInfoText',
 			fill_horizontal = 1,
+		},
+
+		f:static_text {
+			title = bind 'jobTimingLine1',
+			visible = bind 'jobTimingLine1Visible',
+			fill_horizontal = 1,
+			font = '<system/small>',
+			enabled = false,
+		},
+
+		f:static_text {
+			title = bind 'jobTimingLine2',
+			visible = bind 'jobTimingLine2Visible',
+			fill_horizontal = 1,
+			font = '<system/small>',
+			enabled = false,
 		},
 
 		f:spacer { height = 8 },

--- a/plugin/photometoria.lrdevplugin/TaskDialogUI.lua
+++ b/plugin/photometoria.lrdevplugin/TaskDialogUI.lua
@@ -243,6 +243,11 @@ local dialogOpen = false
 local spinnerActive = false
 local onJobSelected
 
+local etaJobId = nil
+local etaAvgSecondsPerPhoto = nil
+local etaElapsedAtLastCompletion = 0
+local etaLastSeenProcessed = 0
+
 --- Fetches jobs for all tasks and stores them in jobsByTaskId.
 local function prefetchAllJobs(host, tasks)
 	jobsByTaskId = {}
@@ -392,11 +397,23 @@ end
 local ETA_MIN_PHOTOS = 2
 
 --- Computes estimated remaining seconds for a processing job.
+---
+--- Model: `X * N - T`, where
+---   X = average seconds per photo (recomputed only when a photo completes),
+---   N = photos still to process, including the one currently running,
+---   T = seconds elapsed since the last completion (time into current photo).
+---
+--- Because X and N are frozen between completions and only T grows, the ETA
+--- decreases at one second per second between completions. When a photo
+--- finishes, X is recalculated from the new processed count; this can make
+--- the ETA jump (usually downward, as more data gives a better estimate).
+--- Result is clamped to zero so the last photo never shows a negative value.
+---
 --- Returns nil when there is insufficient data for a reliable estimate.
 local function computeEtaSeconds(job)
 	local processed = job.processed_photo_count or 0
 	local total = job.photo_count or 0
-	if processed < ETA_MIN_PHOTOS or total <= processed then
+	if processed < ETA_MIN_PHOTOS then
 		return nil
 	end
 	local startTime = parseIsoTimestamp(job.started_at)
@@ -407,8 +424,35 @@ local function computeEtaSeconds(job)
 	if elapsed <= 0 then
 		return nil
 	end
-	local rate = processed / elapsed
-	return (total - processed) / rate
+
+	if job.job_id ~= etaJobId then
+		etaJobId = job.job_id
+		etaAvgSecondsPerPhoto = nil
+		etaElapsedAtLastCompletion = 0
+		etaLastSeenProcessed = 0
+	end
+
+	if processed ~= etaLastSeenProcessed or not etaAvgSecondsPerPhoto then
+		etaAvgSecondsPerPhoto = elapsed / processed
+		etaElapsedAtLastCompletion = elapsed
+		etaLastSeenProcessed = processed
+	end
+
+	local remainingPhotos = total - processed
+	local timeIntoCurrent = elapsed - etaElapsedAtLastCompletion
+	local remaining = etaAvgSecondsPerPhoto * remainingPhotos - timeIntoCurrent
+	return math.max(0, remaining)
+end
+
+--- Updates the ETA line (timing line 2) for a processing job.
+--- Reads in-memory data only; safe to call at any cadence without API traffic.
+local function updateEtaLine(props, job)
+	local etaSeconds = computeEtaSeconds(job)
+	if etaSeconds then
+		props.jobTimingLine2 = LOC "$$$/Photometoria/Job/EstimatedRemaining=Est. remaining:" .. ' ~' .. formatDuration(etaSeconds)
+	else
+		props.jobTimingLine2 = LOC "$$$/Photometoria/Job/EtaCalculating=Calculating..."
+	end
 end
 
 --- Updates job detail panel when a job is selected.
@@ -438,12 +482,7 @@ onJobSelected = function(props)
 		props.jobTimingLine1 = LOC "$$$/Photometoria/Job/StartedAt=Started:" .. ' ' .. formatDateTime(job.started_at)
 		props.jobTimingLine1Visible = (job.started_at ~= nil and job.started_at ~= '')
 
-		local etaSeconds = computeEtaSeconds(job)
-		if etaSeconds then
-			props.jobTimingLine2 = LOC "$$$/Photometoria/Job/EstimatedRemaining=Est. remaining:" .. ' ~' .. formatDuration(etaSeconds)
-		else
-			props.jobTimingLine2 = LOC "$$$/Photometoria/Job/EtaCalculating=Calculating..."
-		end
+		updateEtaLine(props, job)
 		props.jobTimingLine2Visible = true
 
 	elseif job.status == 'queued' then
@@ -593,6 +632,21 @@ local function startJobPolling(host, tasks, props)
 			if spinnerActive then
 				props.jobSpinnerText = SPINNER_FRAMES[frame]
 				frame = (frame % #SPINNER_FRAMES) + 1
+			end
+		end
+	end)
+
+	LrTasks.startAsyncTask(function()
+		while dialogOpen do
+			LrTasks.sleep(1)
+			if not dialogOpen then
+				break
+			end
+			local selectedJob = props.selectedJobValue
+			local jobIndex = selectedJob and selectedJob[1]
+			local job = jobIndex and currentJobs[jobIndex]
+			if job and job.status == 'processing' then
+				updateEtaLine(props, job)
 			end
 		end
 	end)

--- a/plugin/photometoria.lrdevplugin/TranslatedStrings_it.txt
+++ b/plugin/photometoria.lrdevplugin/TranslatedStrings_it.txt
@@ -60,6 +60,13 @@
 "$$$/Photometoria/Job/Waiting=In attesa..."
 "$$$/Photometoria/Job/CompletedIn=completato in ^1."
 "$$$/Photometoria/Job/Errors=errori"
+"$$$/Photometoria/Job/CreatedAt=Creato:"
+"$$$/Photometoria/Job/StartedAt=Avviato:"
+"$$$/Photometoria/Job/CompletedAt=Completato:"
+"$$$/Photometoria/Job/FailedAt=Fallito:"
+"$$$/Photometoria/Job/CancelledAt=Annullato:"
+"$$$/Photometoria/Job/EstimatedRemaining=Rimanente stimato:"
+"$$$/Photometoria/Job/EtaCalculating=Calcolo in corso..."
 
 "$$$/Photometoria/Button/ShowPhotos=Mostra foto in libreria"
 "$$$/Photometoria/Button/Delete=Elimina"


### PR DESCRIPTION
Closes #71

## Summary

- **API**: `started_at` is now included in `JobSummary` (previously only in `JobDetailResponse`), so the plugin polling loop has all timing data without extra requests
- **Plugin**: job detail panel now shows start time, end time/duration, and ETA depending on job state
- **Documentation**: `api-reference.md` and Postman collection updated to reflect the schema change

## Changes

### API (`api/src/models/job.rs`)
- Added `started_at: Option<DateTime<Utc>>` to `JobSummary`
- Updated both `From<Job>` and `From<&Job>` conversion impls

### Tests (`api/src/handlers/jobs.rs`)
- Added `test_list_task_jobs_includes_started_at`: verifies queued job has `started_at = null`, processing job has it set

### Plugin (`TaskDialogUI.lua`)
- Extracted `parseIsoTimestamp` from `formatDateTime` for reuse in ETA computation
- Added `formatDuration` to render seconds as `Xm Ys`
- Added `computeEtaSeconds` with a fixed-average model: `ETA = X * N - T`, where X is seconds/photo (recalculated only on completion), N is remaining photos including current, T is time into the current photo — so ETA decreases 1 s/s between completions
- Added `updateEtaLine` helper shared by `onJobSelected` and the new 1-second ETA tick task
- UI shows per-state timing info:
  - **Queued**: creation timestamp
  - **Processing**: start timestamp + live ETA (updates every 1 s, no extra API calls)
  - **Completed / Failed / Cancelled**: start timestamp, end timestamp, elapsed duration

### Localisation (`TranslatedStrings_it.txt`)
- 7 new Italian strings for timing labels and ETA states

## Test plan

- [ ] Start a multi-photo job and verify ETA appears after 2 photos processed
- [ ] Verify ETA decreases every second without flickering
- [ ] Verify ETA makes a small downward adjustment (not upward) when a photo completes under normal conditions
- [ ] Verify queued job shows creation time only
- [ ] Verify completed job shows start time, completion time, and duration
- [ ] Verify failed / cancelled jobs show the correct end label
- [ ] Run Rust test suite: `cargo test` — 367 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)