### PR TITLE
Add recent hosts list to server connection preferences

### DIFF
--- a/plugin/photometoria.lrdevplugin/PluginInfoProvider.lua
+++ b/plugin/photometoria.lrdevplugin/PluginInfoProvider.lua
@@ -8,6 +8,7 @@ local LrApplication = import 'LrApplication'
 local LrTasks = import 'LrTasks'
 
 local ServerConnection = require 'ServerConnection'
+local RecentHosts = require 'RecentHosts'
 
 local bind = LrView.bind
 local LABEL_WIDTH = 130
@@ -58,8 +59,10 @@ end
 
 local function sectionsForTopOfDialog(f, propertyTable)
 	local prefs = LrPrefs.prefsForPlugin()
+	local clearLabel = LOC "$$$/Photometoria/RecentHosts/ClearList=Clear list"
 
 	propertyTable.serverHost = prefs.serverHost or ''
+	propertyTable.recentHostItems = RecentHosts.toComboItems(clearLabel)
 	propertyTable.connectEnabled = false
 	propertyTable.validationMessage = ''
 	propertyTable.connecting = false
@@ -89,7 +92,18 @@ local function sectionsForTopOfDialog(f, propertyTable)
 
 	hideDetails(propertyTable)
 
+	local lastTypedHost = prefs.serverHost or ''
+	local onConnect
+
 	local function onServerHostChanged(propTable, key, value)
+		if value == clearLabel then
+			RecentHosts.clear(lastTypedHost)
+			propTable.recentHostItems = RecentHosts.toComboItems(clearLabel)
+			propTable.serverHost = lastTypedHost
+			return
+		end
+
+		lastTypedHost = value
 		prefs.serverHost = value
 
 		hideStatus(propTable)
@@ -105,6 +119,13 @@ local function sectionsForTopOfDialog(f, propertyTable)
 		if ServerConnection.isValidHostPort(value) then
 			propTable.connectEnabled = not propTable.connecting
 			propTable.validationMessage = ''
+
+			for _, item in ipairs(propTable.recentHostItems) do
+				if item == value then
+					onConnect()
+					break
+				end
+			end
 		else
 			propTable.connectEnabled = false
 			propTable.validationMessage = LOC "$$$/Photometoria/Validation/InvalidHostPort=Invalid format. Use host:port (e.g. 192.168.1.50:8080)"
@@ -113,7 +134,7 @@ local function sectionsForTopOfDialog(f, propertyTable)
 
 	propertyTable:addObserver('serverHost', onServerHostChanged)
 
-	local function onConnect()
+	onConnect = function()
 		local host = propertyTable.serverHost
 		if not ServerConnection.isValidHostPort(host) then
 			return
@@ -138,6 +159,8 @@ local function sectionsForTopOfDialog(f, propertyTable)
 				propertyTable.statusMessage = LOC("$$$/Photometoria/Status/ConnectedTo=Connected to ^1", host)
 				propertyTable.synopsis = onlineStr
 				showDetails(propertyTable, data)
+				RecentHosts.add(host)
+				propertyTable.recentHostItems = RecentHosts.toComboItems(clearLabel)
 			else
 				local unreachableStr = LOC "$$$/Photometoria/Status/Unreachable=Unreachable"
 				propertyTable.statusText = unreachableStr
@@ -173,8 +196,9 @@ local function sectionsForTopOfDialog(f, propertyTable)
 						width = LABEL_WIDTH,
 					},
 
-					f:edit_field {
+					f:combo_box {
 						value = bind 'serverHost',
+						items = bind 'recentHostItems',
 						width_in_chars = 25,
 						immediate = true,
 					},

--- a/plugin/photometoria.lrdevplugin/RecentHosts.lua
+++ b/plugin/photometoria.lrdevplugin/RecentHosts.lua
@@ -1,0 +1,70 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- SPDX-FileCopyrightText: 2026 The Photometoria contributors
+
+local LrPrefs = import 'LrPrefs'
+
+local MAX_RECENT = 10
+local PREFS_KEY = 'recentHosts'
+
+local RecentHosts = {}
+
+--- Returns an array of recently connected host strings, most recent first.
+function RecentHosts.load()
+    local prefs = LrPrefs.prefsForPlugin()
+    local stored = prefs[PREFS_KEY]
+    if type(stored) ~= 'string' or stored == '' then
+        return {}
+    end
+    local hosts = {}
+    for host in stored:gmatch('[^|]+') do
+        hosts[#hosts + 1] = host
+    end
+    return hosts
+end
+
+local function save(hosts)
+    local prefs = LrPrefs.prefsForPlugin()
+    prefs[PREFS_KEY] = table.concat(hosts, '|')
+end
+
+--- Adds a host to the front of the recent list, removing any duplicate entry
+--- and capping the list at MAX_RECENT entries.
+function RecentHosts.add(host)
+    local hosts = RecentHosts.load()
+    for i = #hosts, 1, -1 do
+        if hosts[i] == host then
+            table.remove(hosts, i)
+        end
+    end
+    table.insert(hosts, 1, host)
+    while #hosts > MAX_RECENT do
+        table.remove(hosts)
+    end
+    save(hosts)
+end
+
+--- Clears the recent hosts list, optionally keeping a single host entry.
+function RecentHosts.clear(keepHost)
+    if keepHost and keepHost ~= '' then
+        save({ keepHost })
+    else
+        save({})
+    end
+end
+
+--- Returns the host list as a flat string array for use as combo_box items.
+--- When the list is non-empty, appends clearLabel as the last entry so the user
+--- can remove all hosts directly from the dropdown.
+function RecentHosts.toComboItems(clearLabel)
+    local hosts = RecentHosts.load()
+    local items = {}
+    for _, host in ipairs(hosts) do
+        items[#items + 1] = host
+    end
+    if #hosts > 0 then
+        items[#items + 1] = clearLabel
+    end
+    return items
+end
+
+return RecentHosts

--- a/plugin/photometoria.lrdevplugin/TranslatedStrings_it.txt
+++ b/plugin/photometoria.lrdevplugin/TranslatedStrings_it.txt
@@ -2,6 +2,7 @@
 
 "$$$/Photometoria/Label/Server=Server:"
 "$$$/Photometoria/Button/Connect=Connetti"
+"$$$/Photometoria/RecentHosts/ClearList=Cancella elenco"
 "$$$/Photometoria/Validation/InvalidHostPort=Formato non valido. Usa host:porta (es. 192.168.1.50:8080)"
 
 "$$$/Photometoria/Label/Status=Stato:"


### PR DESCRIPTION
## Summary

- New `RecentHosts.lua` module: persiste gli ultimi 10 host connessi in `LrPrefs` (serializzati con `|`), con `add`, `clear(keepHost)` e `toComboItems`
- `PluginInfoProvider.lua`: campo `edit_field` sostituito con `combo_box` per avere il look nativo "campo + triangolo dropdown" analogo alle directory recenti nella finestra di esportazione
- Selezione di un host dal dropdown avvia la connessione automaticamente
- "Cancella elenco" in fondo al popup rimuove la cronologia mantenendo il server corrente
- Traduzione italiana aggiunta per la voce "Cancella elenco"

## Test plan

- [ ] Connettersi a un server: verificare che l'host compaia nel dropdown alla riapertura del pannello
- [ ] Connettere più server diversi: verificare che la lista cresca fino a 10, con gli host più recenti in cima
- [ ] Selezionare un host dal dropdown: verificare che la connessione parta automaticamente
- [ ] "Cancella elenco": verificare che la cronologia venga svuotata ma il server corrente rimanga nel campo e nel popup
- [ ] Riavvio Lightroom: verificare che la cronologia persista tra sessioni

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)