### PR TITLE
Persist last active task on popup selection

### DIFF
--- a/plugin/photometoria.lrdevplugin/TaskDialogUI.lua
+++ b/plugin/photometoria.lrdevplugin/TaskDialogUI.lua
@@ -980,8 +980,6 @@ local function buildTaskSection(f, props, host, tasks)
 end
 
 --- Builds the job detail panel (right column of jobs section).
---- TODO: job mutation actions (start, retry, restart, cancel, remove) should
---- update prefs.lastActiveTaskId with the current task's task_id.
 local function buildJobDetailPanel(f, props, host, tasks)
 	return f:column {
 		visible = bind 'jobDetailVisible',
@@ -1398,6 +1396,8 @@ function TaskDialogUI.showDialog(host, tasks, maxContextLength)
 			onTaskSelected(propTable, tasks, value)
 			local task = tasks[value]
 			if task then
+				local prefs = LrPrefs.prefsForPlugin()
+				prefs.lastActiveTaskId = task.task_id
 				LrTasks.startAsyncTask(function()
 					local ok, jobs = ServerConnection.listTaskJobs(host, task.task_id)
 					if ok then


### PR DESCRIPTION
## Summary

- Aggiunge `prefs.lastActiveTaskId = task.task_id` nell'observer `selectedTask` in `TaskDialogUI.lua`, in modo che ogni selezione dal popup persista immediatamente la preferenza
- Rimuove il TODO obsoleto su `buildJobDetailPanel` relativo all'aggiornamento di `lastActiveTaskId` sulle azioni dei job

Closes #81

## Test plan

- [ ] Aprire il Task Dialog con più task disponibili
- [ ] Selezionare un task diverso dal popup → chiudere e riaprire il dialog → verificare che il task precedentemente selezionato sia pre-selezionato
- [ ] Eliminare il task attivo → verificare che `lastActiveTaskId` venga cancellato (comportamento già esistente)

🤖 Generated with [Claude Code](https://claude.com/claude-code)