### PR TITLE
Store provider name in Job (#103)

### DIFF
--- a/api/docs/Photometoria.postman_collection.json
+++ b/api/docs/Photometoria.postman_collection.json
@@ -1248,7 +1248,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n    \"job_id\": \"550e8400-e29b-41d4-a716-446655440010\",\n    \"task_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n    \"status\": \"queued\",\n    \"model\": \"qwen3-vl\",\n    \"language\": \"Italian\",\n    \"photo_count\": 15,\n    \"created_at\": \"2024-01-15T10:35:00Z\"\n}"
+                            "body": "{\n    \"job_id\": \"550e8400-e29b-41d4-a716-446655440010\",\n    \"task_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n    \"status\": \"queued\",\n    \"provider\": \"ollama\",\n    \"model\": \"qwen3-vl\",\n    \"language\": \"Italian\",\n    \"photo_count\": 15,\n    \"created_at\": \"2024-01-15T10:35:00Z\"\n}"
                         },
                         {
                             "name": "Task Not Found",
@@ -1489,7 +1489,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "[\n    {\n        \"job_id\": \"550e8400-e29b-41d4-a716-446655440010\",\n        \"status\": \"completed\",\n        \"model\": \"qwen3-vl\",\n        \"language\": \"English\",\n        \"photo_count\": 15,\n        \"queued_photo_count\": 0,\n        \"processed_photo_count\": 15,\n        \"created_at\": \"2024-01-15T10:35:00Z\",\n        \"started_at\": \"2024-01-15T10:35:10Z\",\n        \"completed_at\": \"2024-01-15T10:45:00Z\"\n    }\n]"
+                            "body": "[\n    {\n        \"job_id\": \"550e8400-e29b-41d4-a716-446655440010\",\n        \"status\": \"completed\",\n        \"provider\": \"ollama\",\n        \"model\": \"qwen3-vl\",\n        \"language\": \"English\",\n        \"photo_count\": 15,\n        \"queued_photo_count\": 0,\n        \"processed_photo_count\": 15,\n        \"created_at\": \"2024-01-15T10:35:00Z\",\n        \"started_at\": \"2024-01-15T10:35:10Z\",\n        \"completed_at\": \"2024-01-15T10:45:00Z\"\n    }\n]"
                         },
                         {
                             "name": "Task Not Found",
@@ -1565,7 +1565,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "[\n    {\n        \"job_id\": \"550e8400-e29b-41d4-a716-446655440010\",\n        \"status\": \"completed\",\n        \"model\": \"qwen3-vl\",\n        \"language\": \"English\",\n        \"photo_count\": 15,\n        \"queued_photo_count\": 0,\n        \"processed_photo_count\": 15,\n        \"created_at\": \"2024-01-15T10:35:00Z\",\n        \"started_at\": \"2024-01-15T10:35:10Z\",\n        \"completed_at\": \"2024-01-15T10:45:00Z\"\n    },\n    {\n        \"job_id\": \"550e8400-e29b-41d4-a716-446655440011\",\n        \"status\": \"queued\",\n        \"model\": \"llava\",\n        \"language\": \"Italian\",\n        \"photo_count\": 5,\n        \"queued_photo_count\": 5,\n        \"processed_photo_count\": 0,\n        \"created_at\": \"2024-01-15T11:00:00Z\"\n    }\n]"
+                            "body": "[\n    {\n        \"job_id\": \"550e8400-e29b-41d4-a716-446655440010\",\n        \"status\": \"completed\",\n        \"provider\": \"ollama\",\n        \"model\": \"qwen3-vl\",\n        \"language\": \"English\",\n        \"photo_count\": 15,\n        \"queued_photo_count\": 0,\n        \"processed_photo_count\": 15,\n        \"created_at\": \"2024-01-15T10:35:00Z\",\n        \"started_at\": \"2024-01-15T10:35:10Z\",\n        \"completed_at\": \"2024-01-15T10:45:00Z\"\n    },\n    {\n        \"job_id\": \"550e8400-e29b-41d4-a716-446655440011\",\n        \"status\": \"queued\",\n        \"provider\": \"ollama\",\n        \"model\": \"llava\",\n        \"language\": \"Italian\",\n        \"photo_count\": 5,\n        \"queued_photo_count\": 5,\n        \"processed_photo_count\": 0,\n        \"created_at\": \"2024-01-15T11:00:00Z\"\n    }\n]"
                         }
                     ]
                 },
@@ -1614,7 +1614,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n    \"job_id\": \"550e8400-e29b-41d4-a716-446655440010\",\n    \"task_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n    \"status\": \"queued\",\n    \"model\": \"qwen3-vl\",\n    \"language\": \"English\",\n    \"photo_count\": 15,\n    \"created_at\": \"2024-01-15T10:35:00Z\"\n}"
+                            "body": "{\n    \"job_id\": \"550e8400-e29b-41d4-a716-446655440010\",\n    \"task_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n    \"status\": \"queued\",\n    \"provider\": \"ollama\",\n    \"model\": \"qwen3-vl\",\n    \"language\": \"English\",\n    \"photo_count\": 15,\n    \"created_at\": \"2024-01-15T10:35:00Z\"\n}"
                         },
                         {
                             "name": "Success (processing with progress)",
@@ -1642,7 +1642,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n    \"job_id\": \"550e8400-e29b-41d4-a716-446655440010\",\n    \"task_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n    \"status\": \"processing\",\n    \"model\": \"qwen3-vl\",\n    \"language\": \"English\",\n    \"photo_count\": 15,\n    \"created_at\": \"2024-01-15T10:35:00Z\",\n    \"started_at\": \"2024-01-15T10:35:10Z\",\n    \"progress\": {\n        \"completed\": 5,\n        \"failed\": 1,\n        \"remaining\": 9,\n        \"current_photo_id\": \"550e8400-e29b-41d4-a716-446655440003\"\n    }\n}"
+                            "body": "{\n    \"job_id\": \"550e8400-e29b-41d4-a716-446655440010\",\n    \"task_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n    \"status\": \"processing\",\n    \"provider\": \"ollama\",\n    \"model\": \"qwen3-vl\",\n    \"language\": \"English\",\n    \"photo_count\": 15,\n    \"created_at\": \"2024-01-15T10:35:00Z\",\n    \"started_at\": \"2024-01-15T10:35:10Z\",\n    \"progress\": {\n        \"completed\": 5,\n        \"failed\": 1,\n        \"remaining\": 9,\n        \"current_photo_id\": \"550e8400-e29b-41d4-a716-446655440003\"\n    }\n}"
                         },
                         {
                             "name": "Success (completed)",
@@ -1670,7 +1670,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n    \"job_id\": \"550e8400-e29b-41d4-a716-446655440010\",\n    \"task_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n    \"status\": \"completed\",\n    \"model\": \"qwen3-vl\",\n    \"language\": \"English\",\n    \"photo_count\": 15,\n    \"created_at\": \"2024-01-15T10:35:00Z\",\n    \"started_at\": \"2024-01-15T10:35:10Z\",\n    \"completed_at\": \"2024-01-15T10:45:00Z\"\n}"
+                            "body": "{\n    \"job_id\": \"550e8400-e29b-41d4-a716-446655440010\",\n    \"task_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n    \"status\": \"completed\",\n    \"provider\": \"ollama\",\n    \"model\": \"qwen3-vl\",\n    \"language\": \"English\",\n    \"photo_count\": 15,\n    \"created_at\": \"2024-01-15T10:35:00Z\",\n    \"started_at\": \"2024-01-15T10:35:10Z\",\n    \"completed_at\": \"2024-01-15T10:45:00Z\"\n}"
                         },
                         {
                             "name": "Success (cancelled)",
@@ -1698,7 +1698,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n    \"job_id\": \"550e8400-e29b-41d4-a716-446655440010\",\n    \"task_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n    \"status\": \"cancelled\",\n    \"model\": \"qwen3-vl\",\n    \"language\": \"English\",\n    \"photo_count\": 15,\n    \"created_at\": \"2024-01-15T10:35:00Z\",\n    \"started_at\": \"2024-01-15T10:35:10Z\",\n    \"completed_at\": \"2024-01-15T10:40:00Z\"\n}"
+                            "body": "{\n    \"job_id\": \"550e8400-e29b-41d4-a716-446655440010\",\n    \"task_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n    \"status\": \"cancelled\",\n    \"provider\": \"ollama\",\n    \"model\": \"qwen3-vl\",\n    \"language\": \"English\",\n    \"photo_count\": 15,\n    \"created_at\": \"2024-01-15T10:35:00Z\",\n    \"started_at\": \"2024-01-15T10:35:10Z\",\n    \"completed_at\": \"2024-01-15T10:40:00Z\"\n}"
                         },
                         {
                             "name": "Not Found",
@@ -1857,7 +1857,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n    \"job_id\": \"550e8400-e29b-41d4-a716-446655440010\",\n    \"task_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n    \"status\": \"cancelled\",\n    \"model\": \"qwen3-vl\",\n    \"language\": \"Italian\",\n    \"photo_count\": 15,\n    \"created_at\": \"2024-01-15T10:35:00Z\"\n}"
+                            "body": "{\n    \"job_id\": \"550e8400-e29b-41d4-a716-446655440010\",\n    \"task_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n    \"status\": \"cancelled\",\n    \"provider\": \"ollama\",\n    \"model\": \"qwen3-vl\",\n    \"language\": \"Italian\",\n    \"photo_count\": 15,\n    \"created_at\": \"2024-01-15T10:35:00Z\"\n}"
                         },
                         {
                             "name": "Already Finished",
@@ -1981,7 +1981,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n    \"job_id\": \"550e8400-e29b-41d4-a716-446655440020\",\n    \"task_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n    \"status\": \"queued\",\n    \"model\": \"qwen3-vl\",\n    \"language\": \"Italian\",\n    \"photo_count\": 3,\n    \"created_at\": \"2024-01-15T11:00:00Z\",\n    \"parent_job_id\": \"550e8400-e29b-41d4-a716-446655440010\"\n}"
+                            "body": "{\n    \"job_id\": \"550e8400-e29b-41d4-a716-446655440020\",\n    \"task_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n    \"status\": \"queued\",\n    \"provider\": \"ollama\",\n    \"model\": \"qwen3-vl\",\n    \"language\": \"Italian\",\n    \"photo_count\": 3,\n    \"created_at\": \"2024-01-15T11:00:00Z\",\n    \"parent_job_id\": \"550e8400-e29b-41d4-a716-446655440010\"\n}"
                         },
                         {
                             "name": "Job Still Processing",

--- a/api/docs/api-reference.md
+++ b/api/docs/api-reference.md
@@ -493,6 +493,7 @@ Returns a summary list of all jobs belonging to a specific task.
   {
     "job_id": "12345678-abcd-ef01-2345-6789abcdef01",
     "status": "completed",
+    "provider": "ollama",
     "model": "qwen3-vl",
     "language": "English",
     "photo_count": 15,
@@ -505,7 +506,7 @@ Returns a summary list of all jobs belonging to a specific task.
 ]
 ```
 
-`started_at` is omitted while the job is still `queued`. `completed_at` is omitted when the job has not yet finished.
+`started_at` is omitted while the job is still `queued`. `completed_at` is omitted when the job has not yet finished. `provider` records the name of the AI provider selected at job creation (currently the server's default provider).
 
 **Errors:**
 
@@ -536,6 +537,7 @@ Creates a new analysis job in `queued` status.
   "job_id": "12345678-abcd-ef01-2345-6789abcdef01",
   "task_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
   "status": "queued",
+  "provider": "ollama",
   "model": "qwen3-vl",
   "language": "Italian",
   "photo_count": 15,
@@ -543,7 +545,7 @@ Creates a new analysis job in `queued` status.
 }
 ```
 
-Fields `started_at` and `completed_at` are omitted until the job reaches the corresponding state.
+Fields `started_at` and `completed_at` are omitted until the job reaches the corresponding state. `provider` is populated with the name of the AI provider selected for this job (currently the server's default provider).
 
 **Errors:**
 
@@ -563,6 +565,7 @@ Cancels an active job. Any photos still waiting in the worker buffer are discard
   "job_id": "12345678-abcd-ef01-2345-6789abcdef01",
   "task_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
   "status": "cancelled",
+  "provider": "ollama",
   "model": "qwen3-vl",
   "language": "English",
   "photo_count": 15,
@@ -577,7 +580,7 @@ Cancels an active job. Any photos still waiting in the worker buffer are discard
 
 ### POST /api/jobs/{job_id}/retry
 
-Creates a new job to retry failed and unprocessed photos from a finished job, using the same model. This includes photos that failed during analysis and photos that were never processed (e.g. because the original job was cancelled).
+Creates a new job to retry failed and unprocessed photos from a finished job, using the same provider and model as the original. This includes photos that failed during analysis and photos that were never processed (e.g. because the original job was cancelled).
 
 **Errors:**
 
@@ -592,6 +595,7 @@ Creates a new job to retry failed and unprocessed photos from a finished job, us
   "job_id": "fedcba98-7654-3210-fedc-ba9876543210",
   "task_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
   "status": "queued",
+  "provider": "ollama",
   "model": "qwen3-vl",
   "language": "English",
   "photo_count": 2,
@@ -611,6 +615,7 @@ Returns a summary list of all jobs across all tasks.
   {
     "job_id": "12345678-abcd-ef01-2345-6789abcdef01",
     "status": "completed",
+    "provider": "ollama",
     "model": "qwen3-vl",
     "language": "English",
     "photo_count": 15,
@@ -623,7 +628,7 @@ Returns a summary list of all jobs across all tasks.
 ]
 ```
 
-`started_at` is omitted while the job is still `queued`. `completed_at` is omitted when the job has not yet finished.
+`started_at` is omitted while the job is still `queued`. `completed_at` is omitted when the job has not yet finished. `provider` records the name of the AI provider selected at job creation.
 
 ### GET /api/jobs/{job_id}
 
@@ -636,6 +641,7 @@ Returns the current state of a specific job.
   "job_id": "12345678-abcd-ef01-2345-6789abcdef01",
   "task_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
   "status": "processing",
+  "provider": "ollama",
   "model": "qwen3-vl",
   "language": "English",
   "photo_count": 15,
@@ -754,6 +760,7 @@ Deletes a job. The job must be in a terminal state (`completed`, `failed`, or `c
   "job_id": "string (UUID)",
   "task_id": "string (UUID)",
   "status": "queued|processing|completed|failed|cancelled",
+  "provider": "string",
   "model": "string",
   "language": "string",
   "photo_ids": [
@@ -766,6 +773,8 @@ Deletes a job. The job must be in a terminal state (`completed`, `failed`, or `c
   "completed_at": "ISO 8601 timestamp | null"
 }
 ```
+
+- `provider` — name of the AI provider selected at job creation (from `[ai.providers]` in the server configuration). Jobs persisted before this field was introduced deserialize with `"ollama"` as a fallback.
 
 ### Result
 

--- a/api/src/handlers/info.rs
+++ b/api/src/handlers/info.rs
@@ -130,14 +130,32 @@ mod tests {
         let photo = Photo::new(task1_id, None, "photo1.jpg".to_string(), 5000);
         ts.state.photo_store.create(photo).await.unwrap();
 
-        let job = Job::new(task1_id, "test".to_string(), None, vec![]);
+        let job = Job::new(
+            task1_id,
+            "ollama".to_string(),
+            "test".to_string(),
+            None,
+            vec![],
+        );
         ts.state.job_store.create(job).await.unwrap();
 
-        let mut processing_job = Job::new(task1_id, "test".to_string(), None, vec![]);
+        let mut processing_job = Job::new(
+            task1_id,
+            "ollama".to_string(),
+            "test".to_string(),
+            None,
+            vec![],
+        );
         processing_job.start();
         ts.state.job_store.create(processing_job).await.unwrap();
 
-        let mut finished_job = Job::new(task1_id, "test".to_string(), None, vec![]);
+        let mut finished_job = Job::new(
+            task1_id,
+            "ollama".to_string(),
+            "test".to_string(),
+            None,
+            vec![],
+        );
         finished_job.start();
         finished_job.complete();
         ts.state.job_store.create(finished_job).await.unwrap();

--- a/api/src/handlers/jobs.rs
+++ b/api/src/handlers/jobs.rs
@@ -49,6 +49,14 @@ pub async fn create_job(
             e => AppError::internal_error(e.to_string()),
         })?;
 
+    let provider = state
+        .ai_providers
+        .default_provider_name()
+        .ok_or_else(|| {
+            AppError::service_unavailable("No default AI provider configured".to_string())
+        })?
+        .to_string();
+
     match state.photo_store.list_by_task(task_id).await {
         Ok(photos) => {
             let photo_ids = job_photo_ids(task_id, photos, request.photo_ids)?;
@@ -61,7 +69,7 @@ pub async fn create_job(
             let language = request
                 .language
                 .or_else(|| state.config.ai.default_language.clone());
-            let job = Job::new(task_id, request.model, language, photo_ids);
+            let job = Job::new(task_id, provider, request.model, language, photo_ids);
             let job_response = add_job_to_store(&state.job_store, job).await?;
             Ok((StatusCode::CREATED, Json(job_response)))
         }
@@ -237,9 +245,10 @@ pub async fn retry_job(
         ));
     }
 
-    // Create new job with retriable photos, preserving the language from the original
+    // Create new job with retriable photos, preserving the provider and language from the original
     let new_job = Job::new(
         original_job.task_id,
+        original_job.provider.clone(),
         original_job.model.clone(),
         original_job.language.clone(),
         retriable_photo_ids,
@@ -251,6 +260,7 @@ pub async fn retry_job(
             job_id: created_job.job_id,
             task_id: created_job.task_id,
             status: created_job.status,
+            provider: created_job.provider,
             model: created_job.model,
             language: created_job.language,
             photo_count: created_job.photo_ids.len(),
@@ -637,8 +647,20 @@ mod tests {
         ts.state.photo_store.create(photo1).await.unwrap();
 
         // Create multiple jobs
-        let job1 = Job::new(task_id, "qwen3-vl:8b".to_string(), None, vec![]);
-        let job2 = Job::new(task_id, "llava".to_string(), None, vec![]);
+        let job1 = Job::new(
+            task_id,
+            "ollama".to_string(),
+            "qwen3-vl:8b".to_string(),
+            None,
+            vec![],
+        );
+        let job2 = Job::new(
+            task_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![],
+        );
         ts.state.job_store.create(job1.clone()).await.unwrap();
         ts.state.job_store.create(job2.clone()).await.unwrap();
 
@@ -667,9 +689,21 @@ mod tests {
         ts.state.task_store.create(task).await.unwrap();
 
         // Create jobs with different statuses
-        let mut job1 = Job::new(task_id, "qwen3-vl:8b".to_string(), None, vec![]);
+        let mut job1 = Job::new(
+            task_id,
+            "ollama".to_string(),
+            "qwen3-vl:8b".to_string(),
+            None,
+            vec![],
+        );
         job1.start();
-        let mut job2 = Job::new(task_id, "llava".to_string(), None, vec![]);
+        let mut job2 = Job::new(
+            task_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![],
+        );
         job2.start();
         job2.complete();
 
@@ -706,6 +740,7 @@ mod tests {
 
         let job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![Uuid::new_v4(), Uuid::new_v4()],
@@ -739,6 +774,7 @@ mod tests {
 
         let mut job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![Uuid::new_v4(), Uuid::new_v4()],
@@ -791,6 +827,7 @@ mod tests {
 
         let job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![Uuid::new_v4(), Uuid::new_v4()],
@@ -826,6 +863,7 @@ mod tests {
         let photo2 = Uuid::new_v4();
         let mut job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![photo1, photo2],
@@ -907,6 +945,7 @@ mod tests {
         let photo3 = Uuid::new_v4();
         let mut job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![photo1, photo2, photo3],
@@ -1008,6 +1047,7 @@ mod tests {
 
         let mut job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![Uuid::new_v4()],
@@ -1038,7 +1078,13 @@ mod tests {
         ts.state.task_store.create(task).await.unwrap();
 
         let photo1 = Uuid::new_v4();
-        let mut job = Job::new(task_id, "qwen3-vl:8b".to_string(), None, vec![photo1]);
+        let mut job = Job::new(
+            task_id,
+            "ollama".to_string(),
+            "qwen3-vl:8b".to_string(),
+            None,
+            vec![photo1],
+        );
         job.start();
         // Simulate photo1 having been processed
         job.queued_photo_ids.clear();
@@ -1088,6 +1134,7 @@ mod tests {
         let photo3 = Uuid::new_v4();
         let mut job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![photo1, photo2, photo3],
@@ -1151,6 +1198,7 @@ mod tests {
 
         let job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![Uuid::new_v4()],
@@ -1184,6 +1232,7 @@ mod tests {
 
         let mut job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![Uuid::new_v4()],
@@ -1213,6 +1262,7 @@ mod tests {
 
         let mut job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![Uuid::new_v4()],
@@ -1258,6 +1308,7 @@ mod tests {
 
         let job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![Uuid::new_v4()],
@@ -1285,6 +1336,7 @@ mod tests {
 
         let mut job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![Uuid::new_v4()],
@@ -1313,6 +1365,7 @@ mod tests {
 
         let mut job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![Uuid::new_v4()],
@@ -1344,6 +1397,7 @@ mod tests {
 
         let mut job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![Uuid::new_v4()],
@@ -1415,9 +1469,27 @@ mod tests {
         ts.state.task_store.create(task1).await.unwrap();
         ts.state.task_store.create(task2).await.unwrap();
 
-        let job1 = Job::new(task1_id, "llava".to_string(), None, vec![]);
-        let job2 = Job::new(task1_id, "llava".to_string(), None, vec![]);
-        let job3 = Job::new(task2_id, "llava".to_string(), None, vec![]);
+        let job1 = Job::new(
+            task1_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![],
+        );
+        let job2 = Job::new(
+            task1_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![],
+        );
+        let job3 = Job::new(
+            task2_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![],
+        );
         let job1_id = job1.job_id;
         let job2_id = job2.job_id;
         ts.state.job_store.create(job1).await.unwrap();
@@ -1453,8 +1525,20 @@ mod tests {
         let task_id = task.task_id;
         ts.state.task_store.create(task).await.unwrap();
 
-        let queued_job = Job::new(task_id, "llava".to_string(), None, vec![]);
-        let mut processing_job = Job::new(task_id, "llava".to_string(), None, vec![]);
+        let queued_job = Job::new(
+            task_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![],
+        );
+        let mut processing_job = Job::new(
+            task_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![],
+        );
         processing_job.start();
 
         ts.state.job_store.create(queued_job).await.unwrap();
@@ -1608,6 +1692,7 @@ mod tests {
 
         let mut job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             Some("Italian".to_string()),
             vec![photo_id],
@@ -1623,6 +1708,95 @@ mod tests {
             retry_response.language.as_deref(),
             Some("Italian"),
             "Retry job should preserve language from original job"
+        );
+    }
+
+    // ========================================================================
+    // Tests for provider field population
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_create_job_populates_provider() {
+        let ts = create_test_state().await;
+
+        let task = Task::new(test_catalog_id(), "Test".to_string(), "ctx".to_string());
+        let task_id = task.task_id;
+        ts.state.task_store.create(task).await.unwrap();
+
+        let photo = Photo::new(task_id, None, "p.jpg".to_string(), 100);
+        ts.state.photo_store.create(photo).await.unwrap();
+
+        let request = CreateJobRequest {
+            model: "qwen3-vl:8b".to_string(),
+            language: None,
+            photo_ids: None,
+        };
+
+        let (_, Json(response)) =
+            create_job(State(ts.state.clone()), AppPath(task_id), Json(request))
+                .await
+                .unwrap();
+
+        assert_eq!(
+            response.provider, "test",
+            "JobResponse should be populated with the default provider name"
+        );
+
+        let stored = ts
+            .state
+            .job_store
+            .get(response.job_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            stored.provider, "test",
+            "Persisted job should record the default provider name"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_retry_job_preserves_provider() {
+        let ts = create_test_state().await;
+
+        let task = Task::new(test_catalog_id(), "Test".to_string(), "ctx".to_string());
+        let task_id = task.task_id;
+        ts.state.task_store.create(task).await.unwrap();
+
+        let photo = Photo::new(task_id, None, "p.jpg".to_string(), 100);
+        let photo_id = photo.photo_id;
+        ts.state.photo_store.create(photo).await.unwrap();
+
+        let mut job = Job::new(
+            task_id,
+            "custom-provider".to_string(),
+            "qwen3-vl:8b".to_string(),
+            None,
+            vec![photo_id],
+        );
+        job.fail();
+        ts.state.job_store.create(job.clone()).await.unwrap();
+        ts.state.job_store.update(job.clone()).await.unwrap();
+
+        let Json(retry_response) = retry_job(State(ts.state.clone()), AppPath(job.job_id))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            retry_response.provider, "custom-provider",
+            "Retry job should preserve provider from the original job"
+        );
+
+        let stored = ts
+            .state
+            .job_store
+            .get(retry_response.job_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            stored.provider, "custom-provider",
+            "Persisted retry job should preserve provider from the original job"
         );
     }
 }

--- a/api/src/handlers/photos.rs
+++ b/api/src/handlers/photos.rs
@@ -296,7 +296,13 @@ mod tests {
         let photo_id = photo.photo_id;
         ts.state.photo_store.create(photo).await.unwrap();
 
-        let job = crate::models::Job::new(task_id, "llava".to_string(), None, vec![photo_id]);
+        let job = crate::models::Job::new(
+            task_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![photo_id],
+        );
         ts.state.job_store.create(job).await.unwrap();
 
         let result = delete_photo(State(ts.state.clone()), AppPath(photo_id)).await;
@@ -318,7 +324,13 @@ mod tests {
         let photo_id = photo.photo_id;
         ts.state.photo_store.create(photo).await.unwrap();
 
-        let mut job = crate::models::Job::new(task_id, "llava".to_string(), None, vec![photo_id]);
+        let mut job = crate::models::Job::new(
+            task_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![photo_id],
+        );
         job.start();
         ts.state.job_store.create(job).await.unwrap();
 
@@ -341,7 +353,13 @@ mod tests {
         let photo_id = photo.photo_id;
         ts.state.photo_store.create(photo).await.unwrap();
 
-        let mut job = crate::models::Job::new(task_id, "llava".to_string(), None, vec![photo_id]);
+        let mut job = crate::models::Job::new(
+            task_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![photo_id],
+        );
         job.start();
         job.complete();
         ts.state.job_store.create(job).await.unwrap();

--- a/api/src/handlers/tasks.rs
+++ b/api/src/handlers/tasks.rs
@@ -816,7 +816,13 @@ mod tests {
         .await
         .unwrap();
 
-        let job = crate::models::Job::new(task.task_id, "llava".to_string(), None, vec![]);
+        let job = crate::models::Job::new(
+            task.task_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![],
+        );
         ts.state.job_store.create(job).await.unwrap();
 
         let result = delete_task(State(ts.state.clone()), AppPath(task.task_id)).await;
@@ -840,7 +846,13 @@ mod tests {
         .await
         .unwrap();
 
-        let mut job = crate::models::Job::new(task.task_id, "llava".to_string(), None, vec![]);
+        let mut job = crate::models::Job::new(
+            task.task_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![],
+        );
         job.start();
         ts.state.job_store.create(job).await.unwrap();
 
@@ -865,7 +877,13 @@ mod tests {
         .await
         .unwrap();
 
-        let mut job = crate::models::Job::new(task.task_id, "llava".to_string(), None, vec![]);
+        let mut job = crate::models::Job::new(
+            task.task_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![],
+        );
         job.start();
         job.complete();
         ts.state.job_store.create(job).await.unwrap();
@@ -890,7 +908,13 @@ mod tests {
         .await
         .unwrap();
 
-        let mut job = crate::models::Job::new(task.task_id, "llava".to_string(), None, vec![]);
+        let mut job = crate::models::Job::new(
+            task.task_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![],
+        );
         job.cancel();
         ts.state.job_store.create(job).await.unwrap();
 
@@ -1063,9 +1087,27 @@ mod tests {
         .await
         .unwrap();
 
-        let job1 = Job::new(task1.task_id, "llava".to_string(), None, vec![]);
-        let job2 = Job::new(task1.task_id, "llava".to_string(), None, vec![]);
-        let job3 = Job::new(task2.task_id, "llava".to_string(), None, vec![]);
+        let job1 = Job::new(
+            task1.task_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![],
+        );
+        let job2 = Job::new(
+            task1.task_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![],
+        );
+        let job3 = Job::new(
+            task2.task_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![],
+        );
         ts.state.job_store.create(job1).await.unwrap();
         ts.state.job_store.create(job2).await.unwrap();
         ts.state.job_store.create(job3).await.unwrap();
@@ -1102,10 +1144,22 @@ mod tests {
         .await
         .unwrap();
 
-        let mut job1 = Job::new(task.task_id, "llava".to_string(), None, vec![]);
+        let mut job1 = Job::new(
+            task.task_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![],
+        );
         job1.start();
         job1.complete();
-        let mut job2 = Job::new(task.task_id, "llava".to_string(), None, vec![]);
+        let mut job2 = Job::new(
+            task.task_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![],
+        );
         job2.cancel();
         ts.state.job_store.create(job1).await.unwrap();
         ts.state.job_store.create(job2).await.unwrap();
@@ -1193,8 +1247,20 @@ mod tests {
         .await
         .unwrap();
 
-        let job1 = Job::new(task.task_id, "llava".to_string(), None, vec![]);
-        let job2 = Job::new(task.task_id, "llava".to_string(), None, vec![]);
+        let job1 = Job::new(
+            task.task_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![],
+        );
+        let job2 = Job::new(
+            task.task_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![],
+        );
         ts.state.job_store.create(job1).await.unwrap();
         ts.state.job_store.create(job2).await.unwrap();
 

--- a/api/src/models/job.rs
+++ b/api/src/models/job.rs
@@ -94,6 +94,10 @@ impl std::fmt::Display for JobStatus {
     }
 }
 
+fn default_legacy_provider() -> String {
+    "ollama".to_string()
+}
+
 // ============================================================================
 // Job Entity (Internal Domain Model)
 // ============================================================================
@@ -114,6 +118,16 @@ pub struct Job {
 
     /// Reference to the parent Task
     pub task_id: Uuid,
+
+    /// Name of the AI provider resolved at job creation (e.g., "ollama").
+    ///
+    /// Persisted so the provider used for analysis can be audited after the fact,
+    /// independently of runtime configuration changes.
+    ///
+    /// Defaults to "ollama" when deserializing jobs persisted before this field
+    /// existed — at that time ollama was the only supported provider.
+    #[serde(default = "default_legacy_provider")]
+    pub provider: String,
 
     /// AI model to use for analysis (e.g., "qwen3-vl:8b", "llava")
     pub model: String,
@@ -154,6 +168,7 @@ impl Job {
     ///
     /// # Arguments
     /// * `task_id` - The UUID of the parent Task
+    /// * `provider` - The AI provider name resolved at creation time
     /// * `model` - The AI model to use for analysis
     /// * `language` - Optional language for generated tags (None = server default)
     /// * `photo_ids` - UUIDs of photos to process
@@ -165,6 +180,7 @@ impl Job {
     ///
     /// let job = Job::new(
     ///     Uuid::new_v4(),
+    ///     "ollama".to_string(),
     ///     "qwen3-vl:8b".to_string(),
     ///     None,
     ///     vec![Uuid::new_v4(), Uuid::new_v4()],
@@ -173,6 +189,7 @@ impl Job {
     /// ```
     pub fn new(
         task_id: Uuid,
+        provider: String,
         model: String,
         language: Option<String>,
         photo_ids: Vec<Uuid>,
@@ -181,6 +198,7 @@ impl Job {
         Self {
             job_id: Uuid::new_v4(),
             task_id,
+            provider,
             model,
             language,
             status: JobStatus::Queued,
@@ -358,6 +376,9 @@ pub struct JobResponse {
     /// Current status
     pub status: JobStatus,
 
+    /// AI provider used
+    pub provider: String,
+
     /// AI model used
     pub model: String,
 
@@ -409,6 +430,9 @@ pub struct JobSummary {
 
     /// Current status
     pub status: JobStatus,
+
+    /// AI provider used
+    pub provider: String,
 
     /// AI model used
     pub model: String,
@@ -519,6 +543,9 @@ pub struct JobDetailResponse {
 
     /// Current status
     pub status: JobStatus,
+
+    /// AI provider used
+    pub provider: String,
 
     /// AI model used
     pub model: String,
@@ -638,6 +665,9 @@ pub struct RetryJobResponse {
     /// Status (always "queued")
     pub status: JobStatus,
 
+    /// AI provider (same as original job)
+    pub provider: String,
+
     /// AI model (same as original job)
     pub model: String,
 
@@ -665,6 +695,7 @@ impl From<Job> for JobResponse {
             job_id: job.job_id,
             task_id: job.task_id,
             status: job.status,
+            provider: job.provider,
             model: job.model,
             language: job.language,
             photo_count: job.photo_ids.len(),
@@ -681,6 +712,7 @@ impl From<&Job> for JobResponse {
             job_id: job.job_id,
             task_id: job.task_id,
             status: job.status,
+            provider: job.provider.clone(),
             model: job.model.clone(),
             language: job.language.clone(),
             photo_count: job.photo_ids.len(),
@@ -700,6 +732,7 @@ impl From<Job> for JobSummary {
             job_id: job.job_id,
             task_id: job.task_id,
             status: job.status,
+            provider: job.provider.clone(),
             model: job.model.clone(),
             language: job.language.clone(),
             created_at: job.created_at,
@@ -718,6 +751,7 @@ impl From<&Job> for JobSummary {
             job_id: job.job_id,
             task_id: job.task_id,
             status: job.status,
+            provider: job.provider.clone(),
             model: job.model.clone(),
             language: job.language.clone(),
             created_at: job.created_at,
@@ -734,6 +768,7 @@ impl From<Job> for JobDetailResponse {
             job_id: job.job_id,
             task_id: job.task_id,
             status: job.status,
+            provider: job.provider,
             model: job.model,
             language: job.language,
             photo_count: job.photo_ids.len(),
@@ -752,6 +787,7 @@ impl From<&Job> for JobDetailResponse {
             job_id: job.job_id,
             task_id: job.task_id,
             status: job.status,
+            provider: job.provider.clone(),
             model: job.model.clone(),
             language: job.language.clone(),
             photo_count: job.photo_ids.len(),
@@ -823,7 +859,13 @@ mod tests {
     fn test_job_new_generates_uuid() {
         let task_id = Uuid::new_v4();
         let photo_id = Uuid::new_v4();
-        let job = Job::new(task_id, "qwen3-vl:8b".to_string(), None, vec![photo_id]);
+        let job = Job::new(
+            task_id,
+            "ollama".to_string(),
+            "qwen3-vl:8b".to_string(),
+            None,
+            vec![photo_id],
+        );
         assert!(!job.job_id.is_nil());
     }
 
@@ -831,9 +873,16 @@ mod tests {
     fn test_job_new_sets_fields() {
         let task_id = Uuid::new_v4();
         let photo_ids = vec![Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4()];
-        let job = Job::new(task_id, "llava".to_string(), None, photo_ids.clone());
+        let job = Job::new(
+            task_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            photo_ids.clone(),
+        );
 
         assert_eq!(job.task_id, task_id);
+        assert_eq!(job.provider, "ollama");
         assert_eq!(job.model, "llava");
         assert_eq!(job.status, JobStatus::Queued);
         assert_eq!(job.photo_ids, photo_ids);
@@ -848,6 +897,7 @@ mod tests {
         let task_id = Uuid::new_v4();
         let job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![Uuid::new_v4(), Uuid::new_v4()],
@@ -862,6 +912,7 @@ mod tests {
         let task_id = Uuid::new_v4();
         let mut job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![Uuid::new_v4()],
@@ -881,6 +932,7 @@ mod tests {
         let task_id = Uuid::new_v4();
         let mut job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![Uuid::new_v4()],
@@ -899,6 +951,7 @@ mod tests {
         let task_id = Uuid::new_v4();
         let mut job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![Uuid::new_v4()],
@@ -916,6 +969,7 @@ mod tests {
         let task_id = Uuid::new_v4();
         let mut job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![Uuid::new_v4()],
@@ -932,6 +986,7 @@ mod tests {
         let task_id = Uuid::new_v4();
         let mut job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![Uuid::new_v4()],
@@ -985,6 +1040,7 @@ mod tests {
         let task_id = Uuid::new_v4();
         let mut job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![Uuid::new_v4(), Uuid::new_v4()],
@@ -1005,7 +1061,13 @@ mod tests {
     #[test]
     fn test_job_to_summary_conversion() {
         let task_id = Uuid::new_v4();
-        let job = Job::new(task_id, "llava".to_string(), None, vec![Uuid::new_v4()]);
+        let job = Job::new(
+            task_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![Uuid::new_v4()],
+        );
 
         let summary: JobSummary = (&job).into();
 
@@ -1043,6 +1105,7 @@ mod tests {
         let task_id = Uuid::new_v4();
         let job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![Uuid::new_v4()],
@@ -1060,6 +1123,7 @@ mod tests {
         let task_id = Uuid::new_v4();
         let job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![Uuid::new_v4()],
@@ -1085,6 +1149,7 @@ mod tests {
         let task_id = Uuid::new_v4();
         let job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![Uuid::new_v4()],
@@ -1097,6 +1162,7 @@ mod tests {
         let task_id = Uuid::new_v4();
         let job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![Uuid::new_v4(), Uuid::new_v4()],
@@ -1120,6 +1186,7 @@ mod tests {
 
         let mut job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![photo1, photo2, photo3],
@@ -1165,6 +1232,7 @@ mod tests {
 
         let mut job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![photo1, photo2],
@@ -1181,6 +1249,7 @@ mod tests {
         let task_id = Uuid::new_v4();
         let job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![Uuid::new_v4(), Uuid::new_v4()],
@@ -1198,6 +1267,7 @@ mod tests {
 
         let mut job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![photo1, photo2, photo3],
@@ -1264,6 +1334,7 @@ mod tests {
         let task_id = Uuid::new_v4();
         let mut job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![Uuid::new_v4(), Uuid::new_v4()],
@@ -1286,6 +1357,7 @@ mod tests {
         let task_id = Uuid::new_v4();
         let job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![Uuid::new_v4(), Uuid::new_v4()],
@@ -1305,6 +1377,7 @@ mod tests {
 
         let mut job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![photo1, photo2],
@@ -1339,6 +1412,7 @@ mod tests {
 
         let mut job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             None,
             vec![photo1, photo2, photo3],
@@ -1402,6 +1476,7 @@ mod tests {
         let task_id = Uuid::new_v4();
         let job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             Some("Italian".to_string()),
             vec![Uuid::new_v4()],
@@ -1412,7 +1487,13 @@ mod tests {
     #[test]
     fn test_job_new_without_language() {
         let task_id = Uuid::new_v4();
-        let job = Job::new(task_id, "llava".to_string(), None, vec![Uuid::new_v4()]);
+        let job = Job::new(
+            task_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![Uuid::new_v4()],
+        );
         assert!(job.language.is_none());
     }
 
@@ -1421,6 +1502,7 @@ mod tests {
         let task_id = Uuid::new_v4();
         let job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             Some("French".to_string()),
             vec![Uuid::new_v4()],
@@ -1433,7 +1515,13 @@ mod tests {
     #[test]
     fn test_job_response_skips_none_language() {
         let task_id = Uuid::new_v4();
-        let job = Job::new(task_id, "llava".to_string(), None, vec![Uuid::new_v4()]);
+        let job = Job::new(
+            task_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![Uuid::new_v4()],
+        );
 
         let response: JobResponse = job.into();
         let json = serde_json::to_string(&response).unwrap();
@@ -1445,6 +1533,7 @@ mod tests {
         let task_id = Uuid::new_v4();
         let job = Job::new(
             task_id,
+            "ollama".to_string(),
             "llava".to_string(),
             Some("Spanish".to_string()),
             vec![Uuid::new_v4()],
@@ -1459,6 +1548,7 @@ mod tests {
         let task_id = Uuid::new_v4();
         let mut job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             Some("German".to_string()),
             vec![Uuid::new_v4()],
@@ -1492,6 +1582,7 @@ mod tests {
         let task_id = Uuid::new_v4();
         let job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             Some("Italian".to_string()),
             vec![Uuid::new_v4()],
@@ -1503,7 +1594,13 @@ mod tests {
     #[test]
     fn test_job_serialization_skips_none_language() {
         let task_id = Uuid::new_v4();
-        let job = Job::new(task_id, "llava".to_string(), None, vec![Uuid::new_v4()]);
+        let job = Job::new(
+            task_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![Uuid::new_v4()],
+        );
         let json = serde_json::to_string(&job).unwrap();
         assert!(!json.contains("\"language\""));
     }
@@ -1513,6 +1610,7 @@ mod tests {
         let task_id = Uuid::new_v4();
         let job = Job::new(
             task_id,
+            "ollama".to_string(),
             "qwen3-vl:8b".to_string(),
             Some("Italian".to_string()),
             vec![Uuid::new_v4()],
@@ -1539,5 +1637,97 @@ mod tests {
             job.language.is_none(),
             "Missing language field should deserialize as None for backward compatibility"
         );
+        assert_eq!(
+            job.provider, "ollama",
+            "Missing provider field should default to 'ollama' for backward compatibility"
+        );
+    }
+
+    // ========================================================================
+    // Provider field tests
+    // ========================================================================
+
+    #[test]
+    fn test_job_new_sets_provider() {
+        let task_id = Uuid::new_v4();
+        let job = Job::new(
+            task_id,
+            "custom-provider".to_string(),
+            "llava".to_string(),
+            None,
+            vec![Uuid::new_v4()],
+        );
+        assert_eq!(job.provider, "custom-provider");
+    }
+
+    #[test]
+    fn test_job_response_includes_provider() {
+        let task_id = Uuid::new_v4();
+        let job = Job::new(
+            task_id,
+            "ollama".to_string(),
+            "qwen3-vl:8b".to_string(),
+            None,
+            vec![Uuid::new_v4()],
+        );
+        let response: JobResponse = (&job).into();
+        assert_eq!(response.provider, "ollama");
+    }
+
+    #[test]
+    fn test_job_summary_includes_provider() {
+        let task_id = Uuid::new_v4();
+        let job = Job::new(
+            task_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![Uuid::new_v4()],
+        );
+        let summary: JobSummary = (&job).into();
+        assert_eq!(summary.provider, "ollama");
+    }
+
+    #[test]
+    fn test_job_detail_response_includes_provider() {
+        let task_id = Uuid::new_v4();
+        let job = Job::new(
+            task_id,
+            "ollama".to_string(),
+            "qwen3-vl:8b".to_string(),
+            None,
+            vec![Uuid::new_v4()],
+        );
+        let response: JobDetailResponse = (&job).into();
+        assert_eq!(response.provider, "ollama");
+    }
+
+    #[test]
+    fn test_job_serialization_includes_provider() {
+        let task_id = Uuid::new_v4();
+        let job = Job::new(
+            task_id,
+            "ollama".to_string(),
+            "llava".to_string(),
+            None,
+            vec![Uuid::new_v4()],
+        );
+        let json = serde_json::to_string(&job).unwrap();
+        assert!(json.contains("\"provider\":\"ollama\""));
+    }
+
+    #[test]
+    fn test_job_roundtrip_preserves_provider() {
+        let task_id = Uuid::new_v4();
+        let job = Job::new(
+            task_id,
+            "custom-provider".to_string(),
+            "llava".to_string(),
+            None,
+            vec![Uuid::new_v4()],
+        );
+        let json = serde_json::to_string(&job).unwrap();
+        let deserialized: Job = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.provider, "custom-provider");
     }
 }

--- a/api/src/services/worker/processor.rs
+++ b/api/src/services/worker/processor.rs
@@ -547,6 +547,7 @@ mod tests {
             .job_store
             .create(Job::new(
                 task.task_id,
+                "ollama".to_string(),
                 "llava".to_string(),
                 None,
                 vec![photo_id],
@@ -828,6 +829,7 @@ mod tests {
             .job_store
             .create(Job::new(
                 task.task_id,
+                "ollama".to_string(),
                 "llava".to_string(),
                 None,
                 vec![photo_id_1, photo_id_2],
@@ -927,6 +929,7 @@ mod tests {
             .job_store
             .create(Job::new(
                 task.task_id,
+                "ollama".to_string(),
                 "llava".to_string(),
                 None,
                 vec![photo_id],

--- a/api/src/services/worker/queue.rs
+++ b/api/src/services/worker/queue.rs
@@ -149,7 +149,13 @@ mod tests {
 
     fn make_job(model: &str, photo_count: usize) -> Job {
         let photo_ids = (0..photo_count).map(|_| Uuid::new_v4()).collect();
-        Job::new(Uuid::new_v4(), model.to_string(), None, photo_ids)
+        Job::new(
+            Uuid::new_v4(),
+            "ollama".to_string(),
+            model.to_string(),
+            None,
+            photo_ids,
+        )
     }
 
     // --- enqueue_job ---

--- a/api/src/services/worker/worker.rs
+++ b/api/src/services/worker/worker.rs
@@ -258,6 +258,7 @@ mod tests {
         if count_a > 0 {
             let job = Job::new(
                 Uuid::new_v4(),
+                "ollama".to_string(),
                 "modelA".to_string(),
                 None,
                 (0..count_a).map(|_| Uuid::new_v4()).collect(),
@@ -267,6 +268,7 @@ mod tests {
         if count_b > 0 {
             let job = Job::new(
                 Uuid::new_v4(),
+                "ollama".to_string(),
                 "modelB".to_string(),
                 None,
                 (0..count_b).map(|_| Uuid::new_v4()).collect(),
@@ -359,6 +361,7 @@ mod tests {
         let mut buf = PhotoBuffer::new();
         let job = Job::new(
             Uuid::new_v4(),
+            "ollama".to_string(),
             "solo".to_string(),
             None,
             (0..3).map(|_| Uuid::new_v4()).collect(),

--- a/api/src/storage/filesystem_job_store.rs
+++ b/api/src/storage/filesystem_job_store.rs
@@ -465,7 +465,13 @@ mod tests {
     }
 
     fn create_test_job(task_id: Uuid, model: &str, photo_ids: Vec<Uuid>) -> Job {
-        Job::new(task_id, model.to_string(), None, photo_ids)
+        Job::new(
+            task_id,
+            "ollama".to_string(),
+            model.to_string(),
+            None,
+            photo_ids,
+        )
     }
 
     fn create_test_job_with_timestamp(
@@ -474,7 +480,13 @@ mod tests {
         photo_ids: Vec<Uuid>,
         timestamp: DateTime<Utc>,
     ) -> Job {
-        let job = Job::new(task_id, model.to_string(), None, photo_ids);
+        let job = Job::new(
+            task_id,
+            "ollama".to_string(),
+            model.to_string(),
+            None,
+            photo_ids,
+        );
         let mut job_value = serde_json::to_value(&job).unwrap();
         job_value["created_at"] = serde_json::to_value(timestamp).unwrap();
         serde_json::from_value(job_value).unwrap()


### PR DESCRIPTION
## Summary

- Add `provider: String` to `Job`, persisted and exposed in `JobResponse`, `JobSummary`, `JobDetailResponse`, and `RetryJobResponse`.
- Populate `provider` at job creation from the registry's default provider; preserve it on retry from the original job.
- Legacy jobs persisted before this change deserialize with `provider = "ollama"` via `#[serde(default)]` — consistent with ollama being the only supported provider until now.

## Scope

Worker dispatch still uses the registry's default provider. Per-job provider dispatch requires structural changes to the worker pool (provider binding), `PhotoProcessor`, and `PhotoBuffer` (model-based grouping is ollama-centric) — these are deferred to the generic worker refactor in #94 (documented there).

## Test plan

- [x] Unit tests for `Job::new`, DTO conversions, serde roundtrip, legacy deserialization default
- [x] Handler tests: `test_create_job_populates_provider`, `test_retry_job_preserves_provider`
- [x] `cargo fmt` clean, `cargo test` green (389 unit + 12 integration)
- [ ] Verify existing persisted jobs on disk still load correctly after deployment

## Docs

- `api/docs/api-reference.md` — updated all job response examples and the Job data model
- `api/docs/Photometoria.postman_collection.json` — updated sample responses

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)