### PR TITLE
Require explicit provider in job creation request

### DIFF
--- a/api/docs/Photometoria.postman_collection.json
+++ b/api/docs/Photometoria.postman_collection.json
@@ -1195,7 +1195,7 @@
                         ],
                         "body": {
                             "mode": "raw",
-                            "raw": "{\n    \"model\": \"qwen3-vl\",\n    \"photo_ids\": null,\n    \"language\": \"Italian\"\n}"
+                            "raw": "{\n    \"provider\": \"ollama\",\n    \"model\": \"qwen3-vl\",\n    \"photo_ids\": null,\n    \"language\": \"Italian\"\n}"
                         },
                         "url": {
                             "raw": "{{base_url}}/api/tasks/{{task_id}}/jobs",
@@ -1209,7 +1209,7 @@
                                 "jobs"
                             ]
                         },
-                        "description": "Creates a new job to process photos with the specified AI model.\n\n- `model`: AI model to use (e.g. `qwen3-vl`, `llava`)\n- `photo_ids`: array of photo UUIDs to process, or `null` to process all photos in the task\n- `language`: language for generated tags (optional). Falls back to server-side `default_language` config, then to English\n\nThe job is created in `queued` status. The `job_id` is saved automatically for subsequent requests."
+                        "description": "Creates a new job to process photos with the specified AI provider and model.\n\n- `provider`: AI provider to use (e.g. `ollama`). Must match a registered provider name from `GET /api/providers`\n- `model`: AI model to use (e.g. `qwen3-vl`, `llava`). Must be configured for the specified provider\n- `photo_ids`: array of photo UUIDs to process, or `null` to process all photos in the task\n- `language`: language for generated tags (optional). Falls back to server-side `default_language` config, then to English\n\nThe job is created in `queued` status. The `job_id` is saved automatically for subsequent requests."
                     },
                     "response": [
                         {
@@ -1224,7 +1224,7 @@
                                 ],
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n    \"model\": \"qwen3-vl\",\n    \"photo_ids\": null,\n    \"language\": \"Italian\"\n}"
+                                    "raw": "{\n    \"provider\": \"ollama\",\n    \"model\": \"qwen3-vl\",\n    \"photo_ids\": null,\n    \"language\": \"Italian\"\n}"
                                 },
                                 "url": {
                                     "raw": "{{base_url}}/api/tasks/{{task_id}}/jobs",
@@ -1262,7 +1262,7 @@
                                 ],
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n    \"model\": \"qwen3-vl\",\n    \"photo_ids\": null,\n    \"language\": \"Italian\"\n}"
+                                    "raw": "{\n    \"provider\": \"ollama\",\n    \"model\": \"qwen3-vl\",\n    \"photo_ids\": null,\n    \"language\": \"Italian\"\n}"
                                 },
                                 "url": {
                                     "raw": "{{base_url}}/api/tasks/nonexistent/jobs",
@@ -1300,7 +1300,7 @@
                                 ],
                                 "body": {
                                     "mode": "raw",
-                                    "raw": "{\n    \"model\": \"qwen3-vl\",\n    \"photo_ids\": [\"00000000-0000-0000-0000-000000000000\"]\n}"
+                                    "raw": "{\n    \"provider\": \"ollama\",\n    \"model\": \"qwen3-vl\",\n    \"photo_ids\": [\"00000000-0000-0000-0000-000000000000\"]\n}"
                                 },
                                 "url": {
                                     "raw": "{{base_url}}/api/tasks/{{task_id}}/jobs",

--- a/api/docs/api-reference.md
+++ b/api/docs/api-reference.md
@@ -520,13 +520,15 @@ Creates a new analysis job in `queued` status.
 
 ```json
 {
+  "provider": "ollama",
   "model": "qwen3-vl",
   "photo_ids": null,
   "language": "Italian"
 }
 ```
 
-- `model`: AI model to use (e.g. `qwen3-vl`, `llava`)
+- `provider`: AI provider to use (e.g. `ollama`). Must match a registered provider name from `GET /api/providers`
+- `model`: AI model to use (e.g. `qwen3-vl`, `llava`). Must be configured for the specified provider
 - `photo_ids`: array of photo UUIDs to process, or `null` to process all photos in the task
 - `language`: language for generated tags (optional). If omitted, falls back to the server-side `default_language` config, then to `"English"`
 
@@ -545,14 +547,17 @@ Creates a new analysis job in `queued` status.
 }
 ```
 
-Fields `started_at` and `completed_at` are omitted until the job reaches the corresponding state. `provider` is populated with the name of the AI provider selected for this job (currently the server's default provider).
+Fields `started_at` and `completed_at` are omitted until the job reaches the corresponding state. `provider` records the name of the AI provider explicitly specified in the request.
 
 **Errors:**
 
+- `400` - Provider is not configured (`invalid_provider`)
+- `400` - Model is not configured for the specified provider (`invalid_model`)
+- `400` - Model is configured but not available in the provider backend (`model_not_available`)
 - `400` - Task has no photos to process (`no_photos`)
 - `400` - One or more `photo_ids` do not belong to the task (`invalid_parameter`)
-- `400` - Specified model is not configured (`invalid_model`)
 - `404` - Task not found
+- `503` - Provider backend is unreachable (`service_unavailable`)
 
 ### POST /api/jobs/{job_id}/cancel
 
@@ -774,7 +779,7 @@ Deletes a job. The job must be in a terminal state (`completed`, `failed`, or `c
 }
 ```
 
-- `provider` — name of the AI provider selected at job creation (from `[ai.providers]` in the server configuration). Jobs persisted before this field was introduced deserialize with `"ollama"` as a fallback.
+- `provider` — name of the AI provider explicitly specified in the job creation request.
 
 ### Result
 

--- a/api/docs/development.md
+++ b/api/docs/development.md
@@ -406,12 +406,12 @@ curl http://localhost:3000/api/tasks/550e8400-e29b-41d4-a716-446655440000/jobs
 # Default language (falls back to config default_language, then English)
 curl -X POST http://localhost:3000/api/tasks/550e8400-e29b-41d4-a716-446655440000/jobs \
   -H "Content-Type: application/json" \
-  -d '{"model":"qwen3-vl","photo_ids":null}'
+  -d '{"provider":"ollama","model":"qwen3-vl","photo_ids":null}'
 
 # Specify language for generated tags
 curl -X POST http://localhost:3000/api/tasks/550e8400-e29b-41d4-a716-446655440000/jobs \
   -H "Content-Type: application/json" \
-  -d '{"model":"qwen3-vl","photo_ids":null,"language":"Italian"}'
+  -d '{"provider":"ollama","model":"qwen3-vl","photo_ids":null,"language":"Italian"}'
 ```
 
 **8. Create multiple tasks (to test multi-task support):**

--- a/api/src/config/ai.rs
+++ b/api/src/config/ai.rs
@@ -8,6 +8,10 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, Deserialize)]
 pub struct AIConfig {
     /// The default provider to use when none is specified.
+    ///
+    /// **Deprecated**: clients are required to specify the provider explicitly
+    /// in each job creation request (`POST /api/tasks/{id}/jobs`). This field
+    /// is retained for backward compatibility and will be removed in a future version.
     #[serde(default)]
     pub default_provider: Option<String>,
 

--- a/api/src/handlers/jobs.rs
+++ b/api/src/handlers/jobs.rs
@@ -27,14 +27,24 @@ pub async fn create_job(
 ) -> Result<(StatusCode, Json<JobResponse>), AppError> {
     get_existing_task(&state.task_store, task_id).await?;
 
+    if !state.ai_providers.contains(&request.provider) {
+        return Err(AppError::bad_request(
+            "invalid_provider",
+            format!("Provider '{}' is not configured", request.provider),
+        ));
+    }
+
     state
         .ai_providers
-        .check_model_available(None, &request.model)
+        .check_model_available(Some(&request.provider), &request.model)
         .await
         .map_err(|e| match e {
             AIProviderError::ModelNotFound { .. } => AppError::bad_request(
                 "invalid_model",
-                format!("Model '{}' is not configured", request.model),
+                format!(
+                    "Model '{}' is not configured for provider '{}'",
+                    request.model, request.provider
+                ),
             ),
             AIProviderError::ModelNotAvailable { .. } => AppError::bad_request(
                 "model_not_available",
@@ -49,14 +59,6 @@ pub async fn create_job(
             e => AppError::internal_error(e.to_string()),
         })?;
 
-    let provider = state
-        .ai_providers
-        .default_provider_name()
-        .ok_or_else(|| {
-            AppError::service_unavailable("No default AI provider configured".to_string())
-        })?
-        .to_string();
-
     match state.photo_store.list_by_task(task_id).await {
         Ok(photos) => {
             let photo_ids = job_photo_ids(task_id, photos, request.photo_ids)?;
@@ -69,7 +71,13 @@ pub async fn create_job(
             let language = request
                 .language
                 .or_else(|| state.config.ai.default_language.clone());
-            let job = Job::new(task_id, provider, request.model, language, photo_ids);
+            let job = Job::new(
+                task_id,
+                request.provider,
+                request.model,
+                language,
+                photo_ids,
+            );
             let job_response = add_job_to_store(&state.job_store, job).await?;
             Ok((StatusCode::CREATED, Json(job_response)))
         }
@@ -331,6 +339,7 @@ mod tests {
 
         // Create job with all photos (photo_ids = None)
         let request = CreateJobRequest {
+            provider: "test".to_string(),
             model: "qwen3-vl:8b".to_string(),
             language: None,
             photo_ids: None,
@@ -384,6 +393,7 @@ mod tests {
 
         // Create job with only photo1 and photo2
         let request = CreateJobRequest {
+            provider: "test".to_string(),
             model: "llava".to_string(),
             language: None,
             photo_ids: Some(vec![photo1_id, photo2_id]),
@@ -412,6 +422,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_create_job_invalid_provider() {
+        let ts = create_test_state().await;
+
+        let task = Task::new(
+            test_catalog_id(),
+            "Test task".to_string(),
+            "test task".to_string(),
+        );
+        let task_id = task.task_id;
+        ts.state.task_store.create(task).await.unwrap();
+
+        let request = CreateJobRequest {
+            provider: "nonexistent-provider".to_string(),
+            model: "qwen3-vl:8b".to_string(),
+            language: None,
+            photo_ids: None,
+        };
+
+        let result = create_job(State(ts.state.clone()), AppPath(task_id), Json(request)).await;
+
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(error.status, axum::http::StatusCode::BAD_REQUEST);
+        assert_eq!(error.body.error, "invalid_provider");
+        assert!(error.body.message.contains("nonexistent-provider"));
+    }
+
+    #[tokio::test]
     async fn test_create_job_invalid_model() {
         let ts = create_test_state().await;
 
@@ -425,6 +463,7 @@ mod tests {
         ts.state.task_store.create(task).await.unwrap();
 
         let request = CreateJobRequest {
+            provider: "test".to_string(),
             model: "nonexistent-model".to_string(),
             language: None,
             photo_ids: None,
@@ -454,6 +493,7 @@ mod tests {
         ts.state.photo_store.create(photo).await.unwrap();
 
         let request = CreateJobRequest {
+            provider: "test".to_string(),
             model: "qwen3-vl:8b".to_string(),
             language: None,
             photo_ids: None,
@@ -484,6 +524,7 @@ mod tests {
         ts.state.photo_store.create(photo).await.unwrap();
 
         let request = CreateJobRequest {
+            provider: "test".to_string(),
             model: "qwen3-vl:8b".to_string(),
             language: None,
             photo_ids: None,
@@ -503,6 +544,7 @@ mod tests {
         let nonexistent_task_id = Uuid::new_v4();
 
         let request = CreateJobRequest {
+            provider: "test".to_string(),
             model: "qwen3-vl:8b".to_string(),
             language: None,
             photo_ids: None,
@@ -545,6 +587,7 @@ mod tests {
         // Try to create job with a photo_id that doesn't belong to this task
         let invalid_photo_id = Uuid::new_v4();
         let request = CreateJobRequest {
+            provider: "test".to_string(),
             model: "qwen3-vl:8b".to_string(),
             language: None,
             photo_ids: Some(vec![invalid_photo_id]),
@@ -574,6 +617,7 @@ mod tests {
 
         // Create job for empty task
         let request = CreateJobRequest {
+            provider: "test".to_string(),
             model: "qwen3-vl:8b".to_string(),
             language: None,
             photo_ids: None,
@@ -603,6 +647,7 @@ mod tests {
 
         // Explicitly pass an empty photo_ids list
         let request = CreateJobRequest {
+            provider: "test".to_string(),
             model: "qwen3-vl:8b".to_string(),
             language: None,
             photo_ids: Some(vec![]),
@@ -1576,6 +1621,7 @@ mod tests {
         ts.state.photo_store.create(photo).await.unwrap();
 
         let request = CreateJobRequest {
+            provider: "test".to_string(),
             model: "qwen3-vl:8b".to_string(),
             language: Some("Italian".to_string()),
             photo_ids: None,
@@ -1609,6 +1655,7 @@ mod tests {
         ts.state.photo_store.create(photo).await.unwrap();
 
         let request = CreateJobRequest {
+            provider: "test".to_string(),
             model: "qwen3-vl:8b".to_string(),
             language: None,
             photo_ids: None,
@@ -1636,6 +1683,7 @@ mod tests {
         ts.state.photo_store.create(photo).await.unwrap();
 
         let request = CreateJobRequest {
+            provider: "test".to_string(),
             model: "qwen3-vl:8b".to_string(),
             language: None,
             photo_ids: None,
@@ -1663,6 +1711,7 @@ mod tests {
         ts.state.photo_store.create(photo).await.unwrap();
 
         let request = CreateJobRequest {
+            provider: "test".to_string(),
             model: "qwen3-vl:8b".to_string(),
             language: Some("German".to_string()),
             photo_ids: None,
@@ -1727,6 +1776,7 @@ mod tests {
         ts.state.photo_store.create(photo).await.unwrap();
 
         let request = CreateJobRequest {
+            provider: "test".to_string(),
             model: "qwen3-vl:8b".to_string(),
             language: None,
             photo_ids: None,
@@ -1739,7 +1789,7 @@ mod tests {
 
         assert_eq!(
             response.provider, "test",
-            "JobResponse should be populated with the default provider name"
+            "JobResponse should record the explicitly requested provider"
         );
 
         let stored = ts
@@ -1751,7 +1801,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             stored.provider, "test",
-            "Persisted job should record the default provider name"
+            "Persisted job should record the explicitly requested provider"
         );
     }
 

--- a/api/src/handlers/jobs.rs
+++ b/api/src/handlers/jobs.rs
@@ -36,7 +36,7 @@ pub async fn create_job(
 
     state
         .ai_providers
-        .check_model_available(Some(&request.provider), &request.model)
+        .check_model_available(&request.provider, &request.model)
         .await
         .map_err(|e| match e {
             AIProviderError::ModelNotFound { .. } => AppError::bad_request(

--- a/api/src/models/job.rs
+++ b/api/src/models/job.rs
@@ -333,6 +333,10 @@ impl Job {
 /// Note: `photo_ids: null` means "process all photos in the task"
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateJobRequest {
+    /// AI provider to use for analysis (e.g., "ollama").
+    /// Must match a registered provider name.
+    pub provider: String,
+
     /// AI model to use for analysis
     pub model: String,
 
@@ -1082,9 +1086,10 @@ mod tests {
 
     #[test]
     fn test_create_job_request_deserialization() {
-        let json = r#"{"model":"qwen3-vl:8b","photo_ids":null}"#;
+        let json = r#"{"provider":"ollama","model":"qwen3-vl:8b","photo_ids":null}"#;
         let request: CreateJobRequest = serde_json::from_str(json).unwrap();
 
+        assert_eq!(request.provider, "ollama");
         assert_eq!(request.model, "qwen3-vl:8b");
         assert!(request.photo_ids.is_none());
     }
@@ -1093,9 +1098,13 @@ mod tests {
     fn test_create_job_request_with_photo_ids() {
         let id1 = Uuid::new_v4();
         let id2 = Uuid::new_v4();
-        let json = format!(r#"{{"model":"llava","photo_ids":["{}","{}"]}}"#, id1, id2);
+        let json = format!(
+            r#"{{"provider":"ollama","model":"llava","photo_ids":["{}","{}"]}}"#,
+            id1, id2
+        );
         let request: CreateJobRequest = serde_json::from_str(&json).unwrap();
 
+        assert_eq!(request.provider, "ollama");
         assert_eq!(request.model, "llava");
         assert_eq!(request.photo_ids, Some(vec![id1, id2]));
     }
@@ -1561,9 +1570,11 @@ mod tests {
 
     #[test]
     fn test_create_job_request_with_language() {
-        let json = r#"{"model":"qwen3-vl:8b","language":"Italian","photo_ids":null}"#;
+        let json =
+            r#"{"provider":"ollama","model":"qwen3-vl:8b","language":"Italian","photo_ids":null}"#;
         let request: CreateJobRequest = serde_json::from_str(json).unwrap();
 
+        assert_eq!(request.provider, "ollama");
         assert_eq!(request.model, "qwen3-vl:8b");
         assert_eq!(request.language.as_deref(), Some("Italian"));
         assert!(request.photo_ids.is_none());
@@ -1571,9 +1582,10 @@ mod tests {
 
     #[test]
     fn test_create_job_request_without_language() {
-        let json = r#"{"model":"llava","photo_ids":null}"#;
+        let json = r#"{"provider":"ollama","model":"llava","photo_ids":null}"#;
         let request: CreateJobRequest = serde_json::from_str(json).unwrap();
 
+        assert_eq!(request.provider, "ollama");
         assert!(request.language.is_none());
     }
 

--- a/api/src/services/ai/registry.rs
+++ b/api/src/services/ai/registry.rs
@@ -161,7 +161,7 @@ impl ProviderRegistry {
     ///
     /// # Arguments
     ///
-    /// * `provider_name` - Provider to check. `None` uses the default provider.
+    /// * `provider_name` - Name of the provider to check. Must be a registered provider.
     /// * `model_id` - The model ID as used in API requests (config key).
     ///
     /// # Errors
@@ -171,13 +171,10 @@ impl ProviderRegistry {
     /// - `AIProviderError::Unavailable` / `Timeout` if the provider backend is unreachable.
     pub async fn check_model_available(
         &self,
-        provider_name: Option<&str>,
+        provider_name: &str,
         model_id: &str,
     ) -> AIProviderResult<()> {
-        let provider = match provider_name {
-            Some(name) => self.get(name)?,
-            None => self.default_provider()?,
-        };
+        let provider = self.get(provider_name)?;
 
         let backend_name = provider
             .configured_model_details()

--- a/api/src/services/ai/registry.rs
+++ b/api/src/services/ai/registry.rs
@@ -201,6 +201,11 @@ impl ProviderRegistry {
         Ok(())
     }
 
+    /// Returns `true` if a provider with the given name is registered.
+    pub fn contains(&self, name: &str) -> bool {
+        self.providers.contains_key(name)
+    }
+
     pub fn is_empty(&self) -> bool {
         self.providers.is_empty()
     }

--- a/plugin/photometoria.lrdevplugin/ServerConnection.lua
+++ b/plugin/photometoria.lrdevplugin/ServerConnection.lua
@@ -220,9 +220,9 @@ end
 --- On success, data contains job_id, task_id, status, model, photo_count, created_at.
 --- On failure, data contains `message` with the error description.
 --- language: optional language string; omitted from the request when nil.
-function ServerConnection.createJob(host, taskId, model, language)
+function ServerConnection.createJob(host, taskId, provider, model, language)
 	local url = 'http://' .. host .. '/api/tasks/' .. taskId .. '/jobs'
-	local payload = { model = model }
+	local payload = { provider = provider, model = model }
 	if language then
 		payload.language = language
 	end

--- a/plugin/photometoria.lrdevplugin/TaskDialogUI.lua
+++ b/plugin/photometoria.lrdevplugin/TaskDialogUI.lua
@@ -1313,7 +1313,7 @@ local function buildJobsSection(f, props, host, tasks)
 						end
 
 						LrTasks.startAsyncTask(function()
-							local ok, data = ServerConnection.createJob(host, task.task_id, selection.model, selection.language)
+							local ok, data = ServerConnection.createJob(host, task.task_id, selection.provider, selection.model, selection.language)
 							if ok then
 								local newJobId = data.job_id
 								local jOk, jobs = ServerConnection.listTaskJobs(host, task.task_id)


### PR DESCRIPTION
## Summary

Closes #104.

- `CreateJobRequest` now includes a required `provider` field; clients must specify the AI provider explicitly on every `POST /api/tasks/{id}/jobs` call
- Provider is validated against registered providers before model availability is checked (`400 invalid_provider`)
- `ProviderRegistry::check_model_available` signature changed from `Option<&str>` to `&str` — the provider is always required, removing the implicit default-provider fallback path
- `default_provider` in `AIConfig` marked as deprecated in the doc comment (retained for TOML backward compatibility)
- Plugin (`ServerConnection.createJob`) updated to send `provider` in the request payload

## Test plan

- [ ] `test_create_job_invalid_provider` — new test covering the `400 invalid_provider` error
- [ ] All 14 existing `CreateJobRequest` handler tests updated with explicit `provider` field
- [ ] 4 `CreateJobRequest` deserialization tests in `models/job.rs` updated
- [ ] `cargo fmt && cargo clippy && cargo test` — 384 tests pass, 0 failures
- [ ] API reference, development.md curl examples, and Postman collection updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)