### PR TITLE
Add configurable server name to info endpoint and plugin UI

### DIFF
--- a/api/config.toml.example
+++ b/api/config.toml.example
@@ -5,6 +5,9 @@
 # In production mode, config.toml is required.
 
 [server]
+# Human-readable name for this server instance (shown in the plugin connection panel).
+# Default: "Photometoria Server"
+name = "Photometoria Server"
 host = "0.0.0.0"
 port = 8080
 

--- a/api/docs/Photometoria.postman_collection.json
+++ b/api/docs/Photometoria.postman_collection.json
@@ -80,7 +80,7 @@
                                     "value": "application/json"
                                 }
                             ],
-                            "body": "{\n    \"general\": {\n        \"version\": \"0.3.0\"\n    },\n    \"server\": {\n        \"allocated_space_bytes\": 107374182400,\n        \"used_space_bytes\": 25243074560,\n        \"available_space_bytes\": 82131107840,\n        \"available_providers\": [\n            \"ollama\"\n        ],\n        \"default_provider\": \"ollama\",\n        \"active_tasks_count\": 3,\n        \"running_jobs_count\": 1\n    },\n    \"limits\": {\n        \"max_photos_per_request\": 100,\n        \"max_photo_size_bytes\": 20971520,\n        \"max_context_length\": 2000,\n        \"max_concurrent_jobs\": null,\n        \"allowed_photo_types\": [\n            \"image/jpeg\",\n            \"image/png\"\n        ]\n    }\n}"
+                            "body": "{\n    \"general\": {\n        \"name\": \"Photometoria Server\",\n        \"version\": \"0.3.0\"\n    },\n    \"server\": {\n        \"allocated_space_bytes\": 107374182400,\n        \"used_space_bytes\": 25243074560,\n        \"available_space_bytes\": 82131107840,\n        \"available_providers\": [\n            \"ollama\"\n        ],\n        \"default_provider\": \"ollama\",\n        \"active_tasks_count\": 3,\n        \"running_jobs_count\": 1\n    },\n    \"limits\": {\n        \"max_photos_per_request\": 100,\n        \"max_photo_size_bytes\": 20971520,\n        \"max_context_length\": 2000,\n        \"max_concurrent_jobs\": null,\n        \"allowed_photo_types\": [\n            \"image/jpeg\",\n            \"image/png\"\n        ]\n    }\n}"
                         }
                     ]
                 }

--- a/api/docs/api-reference.md
+++ b/api/docs/api-reference.md
@@ -80,6 +80,7 @@ Returns general server information: version, storage usage, available AI provide
 ```json
 {
   "general": {
+    "name": "Photometoria Server",
     "version": "0.3.0"
   },
   "server": {
@@ -101,6 +102,7 @@ Returns general server information: version, storage usage, available AI provide
 }
 ```
 
+- `name` — human-readable name of this server instance (configurable in `[server]`)
 - `allocated_space_bytes` — maximum storage space configured for photos
 - `used_space_bytes` — total size of all uploaded photos across all tasks
 - `available_space_bytes` — remaining storage space (`allocated - used`)

--- a/api/docs/configuration.md
+++ b/api/docs/configuration.md
@@ -71,6 +71,12 @@ Server binding and network configuration.
 
 **Options:**
 
+- **name** (string, optional)
+  - Human-readable name for this server instance
+  - Displayed in the Lightroom plugin connection panel to help distinguish multiple servers
+  - Default: `"Photometoria Server"`
+  - Examples: `"Studio NAS"`, `"Home Server"`
+
 - **host** (string, required)
   - Bind address for the HTTP server
   - Default: `"0.0.0.0"` (all interfaces)
@@ -85,6 +91,7 @@ Server binding and network configuration.
 
 ```toml
 [server]
+name = "Studio NAS"
 host = "0.0.0.0"
 port = 8080
 ```

--- a/api/src/config/server.rs
+++ b/api/src/config/server.rs
@@ -3,9 +3,16 @@
 
 use serde::Deserialize;
 
+fn default_server_name() -> String {
+    "Photometoria Server".to_string()
+}
+
 /// Server configuration section.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ServerConfig {
+    /// Human-readable name for this server instance.
+    #[serde(default = "default_server_name")]
+    pub name: String,
     /// Bind address for the HTTP server.
     pub host: String,
     /// TCP port to listen on.
@@ -16,6 +23,7 @@ impl ServerConfig {
     /// Appends this section's summary to the output buffer.
     pub fn format_summary(&self, out: &mut String) {
         out.push_str(&format!("  [server]\n"));
+        out.push_str(&format!("    name: {}\n", self.name));
         out.push_str(&format!("    host: {}\n", self.host));
         out.push_str(&format!("    port: {}\n", self.port));
     }
@@ -24,6 +32,7 @@ impl ServerConfig {
 impl Default for ServerConfig {
     fn default() -> Self {
         Self {
+            name: default_server_name(),
             host: "0.0.0.0".to_string(),
             port: 3000,
         }

--- a/api/src/handlers/info.rs
+++ b/api/src/handlers/info.rs
@@ -32,6 +32,7 @@ pub async fn info(State(state): State<AppState>) -> Result<Json<InfoResult>, App
 
     let info = InfoResult {
         general: GeneralInfo {
+            name: state.config.server.name.clone(),
             version: version.to_string(),
         },
         server: ServerInfo {
@@ -78,6 +79,7 @@ mod tests {
         assert!(result.is_ok());
         let Json(info_result) = result.unwrap();
 
+        assert_eq!(info_result.general.name, ts.state.config.server.name);
         assert_eq!(info_result.general.version, env!("CARGO_PKG_VERSION"));
         assert_eq!(
             info_result.server.allocated_space_bytes,

--- a/api/src/models/info.rs
+++ b/api/src/models/info.rs
@@ -12,6 +12,7 @@ pub struct InfoResult {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GeneralInfo {
+    pub name: String,
     pub version: String,
 }
 

--- a/plugin/photometoria.lrdevplugin/PluginInfoProvider.lua
+++ b/plugin/photometoria.lrdevplugin/PluginInfoProvider.lua
@@ -120,7 +120,7 @@ local function sectionsForTopOfDialog(f, propertyTable)
 			return
 		end
 
-		if ServerConnection.isValidHostPort(value) then
+		if ServerConnection.isValidHostPort(RecentHosts.extractHost(value)) then
 			propTable.connectEnabled = not propTable.connecting
 			propTable.validationMessage = ''
 
@@ -139,7 +139,7 @@ local function sectionsForTopOfDialog(f, propertyTable)
 	propertyTable:addObserver('serverHost', onServerHostChanged)
 
 	onConnect = function()
-		local host = propertyTable.serverHost
+		local host = RecentHosts.extractHost(propertyTable.serverHost)
 		if not ServerConnection.isValidHostPort(host) then
 			return
 		end
@@ -163,7 +163,7 @@ local function sectionsForTopOfDialog(f, propertyTable)
 				propertyTable.statusMessage = LOC("$$$/Photometoria/Status/ConnectedTo=Connected to ^1", host)
 				propertyTable.synopsis = onlineStr
 				showDetails(propertyTable, data)
-				RecentHosts.add(host)
+				RecentHosts.add(host, data.serverName)
 				propertyTable.recentHostItems = RecentHosts.toComboItems(clearLabel)
 			else
 				local unreachableStr = LOC "$$$/Photometoria/Status/Unreachable=Unreachable"
@@ -178,7 +178,7 @@ local function sectionsForTopOfDialog(f, propertyTable)
 		end)
 	end
 
-	if ServerConnection.isValidHostPort(propertyTable.serverHost) then
+	if ServerConnection.isValidHostPort(RecentHosts.extractHost(propertyTable.serverHost)) then
 		onConnect()
 	end
 

--- a/plugin/photometoria.lrdevplugin/PluginInfoProvider.lua
+++ b/plugin/photometoria.lrdevplugin/PluginInfoProvider.lua
@@ -20,6 +20,8 @@ local function hideStatus(propTable)
 end
 
 local function hideDetails(propTable)
+	propTable.detailNameLabel = ''
+	propTable.detailNameValue = ''
 	propTable.detailStorageAllocLabel = ''
 	propTable.detailStorageAllocValue = ''
 	propTable.detailStorageUsedLabel = ''
@@ -39,6 +41,8 @@ local function hideDetails(propTable)
 end
 
 local function showDetails(propTable, data)
+	propTable.detailNameLabel = LOC "$$$/Photometoria/Detail/ServerName=Server name:"
+	propTable.detailNameValue = data.serverName
 	propTable.detailStorageAllocLabel = LOC "$$$/Photometoria/Detail/StorageAllocated=Storage allocated:"
 	propTable.detailStorageAllocValue = data.storageAllocated
 	propTable.detailStorageUsedLabel = LOC "$$$/Photometoria/Detail/StorageUsed=Storage used:"
@@ -254,6 +258,18 @@ local function sectionsForTopOfDialog(f, propertyTable)
 				f:spacer { height = 10 },
 				f:separator { fill_horizontal = 1 },
 				f:spacer { height = 8 },
+
+				f:row {
+					f:static_text {
+						title = bind 'detailNameLabel',
+						alignment = 'right',
+						width = LABEL_WIDTH,
+					},
+					f:static_text {
+						title = bind 'detailNameValue',
+						fill_horizontal = 1,
+					},
+				},
 
 				f:row {
 					f:static_text {

--- a/plugin/photometoria.lrdevplugin/PluginInfoProvider.lua
+++ b/plugin/photometoria.lrdevplugin/PluginInfoProvider.lua
@@ -97,9 +97,11 @@ local function sectionsForTopOfDialog(f, propertyTable)
 	hideDetails(propertyTable)
 
 	local lastTypedHost = prefs.serverHost or ''
+	local suppressHostObserver = false
 	local onConnect
 
 	local function onServerHostChanged(propTable, key, value)
+		if suppressHostObserver then return end
 		if value == clearLabel then
 			RecentHosts.clear(lastTypedHost)
 			propTable.recentHostItems = RecentHosts.toComboItems(clearLabel)
@@ -165,6 +167,13 @@ local function sectionsForTopOfDialog(f, propertyTable)
 				showDetails(propertyTable, data)
 				RecentHosts.add(host, data.serverName)
 				propertyTable.recentHostItems = RecentHosts.toComboItems(clearLabel)
+				suppressHostObserver = true
+				if data.serverName and data.serverName ~= '' then
+					propertyTable.serverHost = host .. ' - ' .. data.serverName
+				else
+					propertyTable.serverHost = host
+				end
+				suppressHostObserver = false
 			else
 				local unreachableStr = LOC "$$$/Photometoria/Status/Unreachable=Unreachable"
 				propertyTable.statusText = unreachableStr
@@ -172,7 +181,7 @@ local function sectionsForTopOfDialog(f, propertyTable)
 				propertyTable.synopsis = unreachableStr
 			end
 
-			if ServerConnection.isValidHostPort(propertyTable.serverHost) then
+			if ServerConnection.isValidHostPort(RecentHosts.extractHost(propertyTable.serverHost)) then
 				propertyTable.connectEnabled = true
 			end
 		end)

--- a/plugin/photometoria.lrdevplugin/RecentHosts.lua
+++ b/plugin/photometoria.lrdevplugin/RecentHosts.lua
@@ -5,63 +5,87 @@ local LrPrefs = import 'LrPrefs'
 
 local MAX_RECENT = 10
 local PREFS_KEY = 'recentHosts'
+local NAME_SEP = '\1'
 
 local RecentHosts = {}
 
---- Returns an array of recently connected host strings, most recent first.
+--- Returns an array of {host, name} tables, most recent first.
+--- Backward compatible: entries without NAME_SEP have name = ''.
 function RecentHosts.load()
     local prefs = LrPrefs.prefsForPlugin()
     local stored = prefs[PREFS_KEY]
     if type(stored) ~= 'string' or stored == '' then
         return {}
     end
-    local hosts = {}
-    for host in stored:gmatch('[^|]+') do
-        hosts[#hosts + 1] = host
-    end
-    return hosts
-end
-
-local function save(hosts)
-    local prefs = LrPrefs.prefsForPlugin()
-    prefs[PREFS_KEY] = table.concat(hosts, '|')
-end
-
---- Adds a host to the front of the recent list, removing any duplicate entry
---- and capping the list at MAX_RECENT entries.
-function RecentHosts.add(host)
-    local hosts = RecentHosts.load()
-    for i = #hosts, 1, -1 do
-        if hosts[i] == host then
-            table.remove(hosts, i)
+    local entries = {}
+    for entry in stored:gmatch('[^|]+') do
+        local sep = entry:find(NAME_SEP, 1, true)
+        if sep then
+            entries[#entries + 1] = { host = entry:sub(1, sep - 1), name = entry:sub(sep + 1) }
+        else
+            entries[#entries + 1] = { host = entry, name = '' }
         end
     end
-    table.insert(hosts, 1, host)
-    while #hosts > MAX_RECENT do
-        table.remove(hosts)
+    return entries
+end
+
+local function save(entries)
+    local prefs = LrPrefs.prefsForPlugin()
+    local parts = {}
+    for _, e in ipairs(entries) do
+        parts[#parts + 1] = e.host .. NAME_SEP .. e.name
     end
-    save(hosts)
+    prefs[PREFS_KEY] = table.concat(parts, '|')
+end
+
+--- Adds or updates a host entry. If the host already exists, moves it to the
+--- front and updates the name. Caps the list at MAX_RECENT entries.
+function RecentHosts.add(host, name)
+    local entries = RecentHosts.load()
+    for i = #entries, 1, -1 do
+        if entries[i].host == host then
+            table.remove(entries, i)
+        end
+    end
+    table.insert(entries, 1, { host = host, name = name or '' })
+    while #entries > MAX_RECENT do
+        table.remove(entries)
+    end
+    save(entries)
 end
 
 --- Clears the recent hosts list, optionally keeping a single host entry.
 function RecentHosts.clear(keepHost)
     if keepHost and keepHost ~= '' then
-        save({ keepHost })
+        local host = RecentHosts.extractHost(keepHost)
+        save({ { host = host, name = '' } })
     else
         save({})
     end
 end
 
---- Returns the host list as a flat string array for use as combo_box items.
---- When the list is non-empty, appends clearLabel as the last entry so the user
---- can remove all hosts directly from the dropdown.
+--- Extracts the host:port from a display string that may contain a server name.
+--- "192.168.1.50:8080 - Studio NAS" → "192.168.1.50:8080"
+--- "192.168.1.50:8080"              → "192.168.1.50:8080"
+function RecentHosts.extractHost(value)
+    if type(value) ~= 'string' then return '' end
+    return value:match('^(%S+) %- ') or value
+end
+
+--- Returns the host list as display strings for use as combo_box items.
+--- Each entry is formatted as "host - name" when a name is available, or
+--- just "host" otherwise. Appends clearLabel when the list is non-empty.
 function RecentHosts.toComboItems(clearLabel)
-    local hosts = RecentHosts.load()
+    local entries = RecentHosts.load()
     local items = {}
-    for _, host in ipairs(hosts) do
-        items[#items + 1] = host
+    for _, e in ipairs(entries) do
+        if e.name and e.name ~= '' then
+            items[#items + 1] = e.host .. ' - ' .. e.name
+        else
+            items[#items + 1] = e.host
+        end
     end
-    if #hosts > 0 then
+    if #entries > 0 then
         items[#items + 1] = clearLabel
     end
     return items

--- a/plugin/photometoria.lrdevplugin/ServerConnection.lua
+++ b/plugin/photometoria.lrdevplugin/ServerConnection.lua
@@ -102,6 +102,7 @@ function ServerConnection.info(host)
 	local limits = info.limits or {}
 
 	return true, {
+		serverName          = info.general and info.general.name or '',
 		storageAllocated    = formatBytes(allocated),
 		storageUsed         = formatBytes(used),
 		storageFree         = formatBytes(free),

--- a/plugin/photometoria.lrdevplugin/TranslatedStrings_it.txt
+++ b/plugin/photometoria.lrdevplugin/TranslatedStrings_it.txt
@@ -18,6 +18,7 @@
 "$$$/Photometoria/Progress/Validating=Verifica foto..."
 "$$$/Photometoria/Progress/LoadingTasks=Caricamento task..."
 
+"$$$/Photometoria/Detail/ServerName=Nome server:"
 "$$$/Photometoria/Detail/StorageAllocated=Spazio allocato:"
 "$$$/Photometoria/Detail/StorageUsed=Spazio utilizzato:"
 "$$$/Photometoria/Detail/StorageFree=Spazio libero:"

--- a/plugin/tests/test_recent_hosts.lua
+++ b/plugin/tests/test_recent_hosts.lua
@@ -1,0 +1,134 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- SPDX-FileCopyrightText: 2026 The Photometoria contributors
+
+package.path = 'plugin/photometoria.lrdevplugin/?.lua;plugin/tests/?.lua;' .. package.path
+
+local testkit = require 'testkit'
+
+-- Stub the Lightroom SDK so RecentHosts can run outside Lightroom.
+local prefs = {}
+function import(name)
+    if name == 'LrPrefs' then
+        return {
+            prefsForPlugin = function() return prefs end,
+        }
+    end
+    error('unexpected import: ' .. name)
+end
+
+local RecentHosts = require 'RecentHosts'
+
+local function reset()
+    prefs = {}
+end
+
+testkit.suite('RecentHosts tests')
+
+testkit.test('load returns empty table when nothing stored', function()
+    reset()
+    local entries = RecentHosts.load()
+    testkit.assertEqual(#entries, 0)
+end)
+
+testkit.test('add stores host with name', function()
+    reset()
+    RecentHosts.add('192.168.1.50:8080', 'Studio NAS')
+    local entries = RecentHosts.load()
+    testkit.assertEqual(#entries, 1)
+    testkit.assertEqual(entries[1].host, '192.168.1.50:8080')
+    testkit.assertEqual(entries[1].name, 'Studio NAS')
+end)
+
+testkit.test('add stores host without name', function()
+    reset()
+    RecentHosts.add('localhost:3000')
+    local entries = RecentHosts.load()
+    testkit.assertEqual(#entries, 1)
+    testkit.assertEqual(entries[1].host, 'localhost:3000')
+    testkit.assertEqual(entries[1].name, '')
+end)
+
+testkit.test('add moves duplicate to front and updates name', function()
+    reset()
+    RecentHosts.add('host-a:8080', 'Old Name')
+    RecentHosts.add('host-b:8080', 'Server B')
+    RecentHosts.add('host-a:8080', 'New Name')
+    local entries = RecentHosts.load()
+    testkit.assertEqual(#entries, 2)
+    testkit.assertEqual(entries[1].host, 'host-a:8080')
+    testkit.assertEqual(entries[1].name, 'New Name')
+    testkit.assertEqual(entries[2].host, 'host-b:8080')
+end)
+
+testkit.test('load is backward compatible with name-less entries', function()
+    reset()
+    prefs['recentHosts'] = 'oldhost:9000|anotherhost:1234'
+    local entries = RecentHosts.load()
+    testkit.assertEqual(#entries, 2)
+    testkit.assertEqual(entries[1].host, 'oldhost:9000')
+    testkit.assertEqual(entries[1].name, '')
+    testkit.assertEqual(entries[2].host, 'anotherhost:1234')
+    testkit.assertEqual(entries[2].name, '')
+end)
+
+testkit.test('toComboItems returns display string with name', function()
+    reset()
+    RecentHosts.add('192.168.1.50:8080', 'Studio NAS')
+    RecentHosts.add('localhost:3000', '')
+    local items = RecentHosts.toComboItems('Clear list')
+    testkit.assertEqual(#items, 3)
+    testkit.assertEqual(items[1], 'localhost:3000')
+    testkit.assertEqual(items[2], '192.168.1.50:8080 - Studio NAS')
+    testkit.assertEqual(items[3], 'Clear list')
+end)
+
+testkit.test('toComboItems omits clear label when list is empty', function()
+    reset()
+    local items = RecentHosts.toComboItems('Clear list')
+    testkit.assertEqual(#items, 0)
+end)
+
+testkit.test('extractHost strips name suffix', function()
+    reset()
+    testkit.assertEqual(RecentHosts.extractHost('192.168.1.50:8080 - Studio NAS'), '192.168.1.50:8080')
+end)
+
+testkit.test('extractHost returns plain host unchanged', function()
+    reset()
+    testkit.assertEqual(RecentHosts.extractHost('localhost:3000'), 'localhost:3000')
+end)
+
+testkit.test('extractHost handles name containing hyphen', function()
+    reset()
+    testkit.assertEqual(RecentHosts.extractHost('10.0.0.1:8080 - My-Server'), '10.0.0.1:8080')
+end)
+
+testkit.test('clear removes all entries', function()
+    reset()
+    RecentHosts.add('host-a:8080', 'A')
+    RecentHosts.add('host-b:8080', 'B')
+    RecentHosts.clear()
+    local entries = RecentHosts.load()
+    testkit.assertEqual(#entries, 0)
+end)
+
+testkit.test('clear keeps one entry when keepHost provided', function()
+    reset()
+    RecentHosts.add('host-a:8080', 'A')
+    RecentHosts.add('host-b:8080', 'B')
+    RecentHosts.clear('host-a:8080')
+    local entries = RecentHosts.load()
+    testkit.assertEqual(#entries, 1)
+    testkit.assertEqual(entries[1].host, 'host-a:8080')
+end)
+
+testkit.test('clear extracts host from display string', function()
+    reset()
+    RecentHosts.add('host-a:8080', 'A')
+    RecentHosts.clear('host-a:8080 - A')
+    local entries = RecentHosts.load()
+    testkit.assertEqual(#entries, 1)
+    testkit.assertEqual(entries[1].host, 'host-a:8080')
+end)
+
+testkit.report()


### PR DESCRIPTION
## Summary

- Adds a `name` field to `[server]` in `config.toml` (default: `"Photometoria Server"`) and exposes it in `GET /api/info` under `general.name`
- Plugin displays the server name as the first row in the connection details panel
- Recent hosts combo now shows `"host - name"` after a successful connection, and persists the name across sessions; backward compatible with existing stored entries

## Changes

### API
- `ServerConfig`: new `name` field with serde default `"Photometoria Server"`
- `GeneralInfo`: new `name` field populated from config
- Handler test updated to assert `general.name`
- Docs updated: `config.toml.example`, `configuration.md`, `api-reference.md`, Postman collection

### Plugin
- `ServerConnection.info`: parses `general.name` → `serverName` in returned data
- `PluginInfoProvider`: new detail row for server name; combo updated to display string after connect; `suppressHostObserver` flag prevents re-entry
- `RecentHosts`: storage extended to `"host\1name"` format (backward compatible); new `extractHost()` function; `add()` accepts optional name; `toComboItems()` produces display strings
- Italian translation added for `Detail/ServerName`
- 13 unit tests added for `RecentHosts`

## Test plan

- [ ] Build API (`cargo test`) — 384 tests pass
- [ ] Lua plugin tests (`lua5.1 plugin/tests/test_recent_hosts.lua`) — 13 tests pass
- [ ] In Lightroom: type a host manually → click Connect → combo shows `"host - name"`
- [ ] Reload Plugin Manager → combo still shows `"host - name"`
- [ ] Select a recent host from dropdown → auto-connects correctly
- [ ] Server with no `name` in `config.toml` → defaults to `"Photometoria Server"`

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)