### PR TITLE
feat(api): implement CLI subcommands (config check, config show, --version)

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -25,9 +25,9 @@
 
 ```
 api/src/
-├── main.rs           # Entry point, CLI parsing
+├── main.rs           # Entry point, subcommand dispatch (server / config check / config show)
 ├── lib.rs            # Library crate root (re-exports)
-├── cli.rs            # CLI argument definitions (clap)
+├── cli.rs            # CLI definition (clap derive): --config, config check, config show, --version
 ├── startup.rs        # Server initialization and startup logic
 ├── app_state.rs      # Shared application state (AppState)
 ├── config/           # TOML configuration parsing

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.100"
+clap = { version = "4", features = ["derive"] }
 async-trait = "0.1"
 base64 = "0.22"
 infer = "0.16"

--- a/api/docs/configuration.md
+++ b/api/docs/configuration.md
@@ -6,7 +6,13 @@ The Photometoria API server is configured via a TOML file read at startup. This 
 
 ## Configuration File Location
 
-By default, the server looks for `config.toml` in the current working directory. You can specify an alternative path using environment variables or command-line arguments.
+By default, the server looks for `config.toml` in the current working directory. You can specify an alternative path with the `--config` flag, which is available on all commands:
+
+```bash
+photometoria --config /etc/photometoria/config.toml
+photometoria config check --config /etc/photometoria/config.toml
+photometoria config show  --config /etc/photometoria/config.toml
+```
 
 ## Example Configuration
 
@@ -438,6 +444,21 @@ The server validates configuration at startup:
 - Storage paths must be valid and writable
 
 **Startup will fail** if configuration is invalid, with error messages indicating the problem.
+
+To validate the configuration **without starting the server** (useful before deploy):
+
+```bash
+photometoria config check
+photometoria config check --config /etc/photometoria/config.toml
+```
+
+To inspect the **effective configuration** (file values + applied defaults) as valid TOML:
+
+```bash
+photometoria config show
+```
+
+The output of `config show` is valid TOML that can be saved and used directly as a configuration file.
 
 ## See Also
 

--- a/api/docs/development.md
+++ b/api/docs/development.md
@@ -110,10 +110,10 @@ cargo run
 
 # Release build (optimized)
 cargo build --release
-cargo run --release
+./target/release/photometoria
 ```
 
-The server will start on `http://localhost:8080` (or the configured port).
+The server will start on `http://localhost:3000` (or the configured port).
 
 ## Testing
 
@@ -241,6 +241,31 @@ cargo test --test '*'
 cargo tarpaulin --out Html
 ```
 
+### CLI Reference
+
+The `photometoria` binary supports the following commands:
+
+```bash
+# Start the server (default behaviour when no command is given)
+photometoria
+photometoria --config /etc/photometoria/config.toml
+
+# Validate the configuration file without starting the server
+# Exits with code 0 if valid, 1 otherwise
+photometoria config check
+photometoria config check --config custom.toml
+
+# Print the effective configuration as valid TOML
+# Includes all default values; output can be saved and used as a config file
+photometoria config show
+photometoria config show --config custom.toml
+
+# Version and help
+photometoria --version
+photometoria --help
+photometoria config --help
+```
+
 ### Debugging HTTP Requests
 
 The API server includes `tower-http` `TraceLayer` middleware that logs every
@@ -252,13 +277,13 @@ To enable HTTP request logging, set the `RUST_LOG` environment variable:
 
 ```bash
 # Show all HTTP requests/responses (method, URI, status, latency)
-RUST_LOG=tower_http=debug cargo run --release
+RUST_LOG=tower_http=debug photometoria
 
 # Maximum verbosity (includes body sizes, header details)
-RUST_LOG=tower_http=trace cargo run --release
+RUST_LOG=tower_http=trace photometoria
 
 # Combine with application logs
-RUST_LOG=photometoria=debug,tower_http=debug cargo run --release
+RUST_LOG=photometoria=debug,tower_http=debug photometoria
 ```
 
 This is useful for diagnosing client issues (e.g., wrong URL paths) where the
@@ -575,6 +600,7 @@ fn calculate_task_size(photos: &[Photo]) -> Option<u64> {
 - **v0.1.0** - Initial REST API server implementation with core functionality
 - **v0.2.0** - Plugin support (endpoint adjustments, response structure updates)
 - **v0.3.0** - Catalog identity support (catalog-scoped tasks, storage per catalog)
+- **v0.3.1** - CLI subcommands: `config check`, `config show`, `--version`
 
 ## See Also
 

--- a/api/src/cli.rs
+++ b/api/src/cli.rs
@@ -1,75 +1,34 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2026 The Photometoria contributors
 
+use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
-const DEFAULT_CONFIG_PATH: &str = "config.toml";
-
-/// Command-line arguments.
-#[derive(Debug)]
-pub struct Args {
-    /// Path to configuration file.
+/// Photometoria REST API Server
+#[derive(Parser)]
+#[command(name = "photometoria", version)]
+pub struct Cli {
+    /// Path to configuration file
+    #[arg(short = 'c', long, default_value = "config.toml", global = true)]
     pub config: PathBuf,
+
+    #[command(subcommand)]
+    pub command: Option<Command>,
 }
 
-impl Default for Args {
-    fn default() -> Self {
-        Self {
-            config: PathBuf::from(DEFAULT_CONFIG_PATH),
-        }
-    }
+#[derive(Subcommand)]
+pub enum Command {
+    /// Configuration management
+    Config {
+        #[command(subcommand)]
+        subcommand: ConfigCommand,
+    },
 }
 
-/// Parses command-line arguments.
-///
-/// Supports:
-/// - `-c <path>` or `--config <path>`: specify configuration file path
-/// - `-h` or `--help`: show usage information
-///
-/// Returns default arguments if no options are provided.
-pub fn parse_args() -> Args {
-    let mut args = Args::default();
-    let mut iter = std::env::args().skip(1);
-
-    while let Some(arg) = iter.next() {
-        match arg.as_str() {
-            "-h" | "--help" => {
-                print_help();
-                std::process::exit(0);
-            }
-            "-c" | "--config" => {
-                let path = iter.next().unwrap_or_else(|| {
-                    eprintln!("Error: --config requires a path argument");
-                    std::process::exit(1);
-                });
-                args.config = PathBuf::from(path);
-            }
-            other => {
-                eprintln!("Error: unknown argument '{}'", other);
-                eprintln!("Use --help for usage information");
-                std::process::exit(1);
-            }
-        }
-    }
-
-    args
-}
-
-fn print_help() {
-    let binary_name = std::env::args()
-        .next()
-        .unwrap_or_else(|| "photometoria-rest-api".to_string());
-
-    println!(
-        "Photometoria REST API Server
-
-USAGE:
-    {} [OPTIONS]
-
-OPTIONS:
-    -c, --config <PATH>    Path to configuration file [default: config.toml]
-    -h, --help             Print this help message
-",
-        binary_name
-    );
+#[derive(Subcommand)]
+pub enum ConfigCommand {
+    /// Validate the configuration file without starting the server
+    Check,
+    /// Print the effective configuration as valid TOML
+    Show,
 }

--- a/api/src/config/ai.rs
+++ b/api/src/config/ai.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2026 The Photometoria contributors
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// AI provider configuration section.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AIConfig {
     /// The default provider to use when none is specified.
     ///
@@ -61,7 +61,7 @@ impl Default for AIConfig {
 }
 
 /// Configuration for a single AI provider.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(tag = "type")]
 pub enum ProviderConfig {
     /// Ollama provider configuration.
@@ -70,7 +70,7 @@ pub enum ProviderConfig {
 }
 
 /// Ollama-specific provider configuration.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct OllamaProviderConfig {
     /// Base URL for the Ollama API.
     #[serde(default = "OllamaProviderConfig::default_base_url")]
@@ -130,7 +130,7 @@ impl OllamaProviderConfig {
 }
 
 /// Configuration for an Ollama model.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct OllamaModelConfig {
     /// The actual Ollama model name (e.g., "qwen3-vl:8b").
     pub ollama_model: String,

--- a/api/src/config/byte_size.rs
+++ b/api/src/config/byte_size.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2026 The Photometoria contributors
 
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 use std::str::FromStr;
 
@@ -56,6 +56,15 @@ impl<'de> Deserialize<'de> for ByteSize {
         }
 
         deserializer.deserialize_any(ByteSizeVisitor)
+    }
+}
+
+impl Serialize for ByteSize {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
     }
 }
 

--- a/api/src/config/mod.rs
+++ b/api/src/config/mod.rs
@@ -21,7 +21,7 @@ use std::fs;
 use std::path::Path;
 
 /// Application configuration.
-#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize)]
 pub struct Config {
     /// Server binding and network configuration.
     pub server: ServerConfig,

--- a/api/src/config/server.rs
+++ b/api/src/config/server.rs
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2026 The Photometoria contributors
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 fn default_server_name() -> String {
     "Photometoria Server".to_string()
 }
 
 /// Server configuration section.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ServerConfig {
     /// Human-readable name for this server instance.
     #[serde(default = "default_server_name")]

--- a/api/src/config/storage.rs
+++ b/api/src/config/storage.rs
@@ -2,10 +2,10 @@
 // SPDX-FileCopyrightText: 2026 The Photometoria contributors
 
 use super::ByteSize;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Storage configuration section
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct StorageConfig {
     pub path: String,
     pub max_size: ByteSize,

--- a/api/src/config/task.rs
+++ b/api/src/config/task.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2026 The Photometoria contributors
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Task configuration section.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct TaskConfig {
     /// Maximum allowed length of a task context in characters.
     pub max_context_length: usize,

--- a/api/src/config/upload.rs
+++ b/api/src/config/upload.rs
@@ -2,10 +2,10 @@
 // SPDX-FileCopyrightText: 2026 The Photometoria contributors
 
 use super::ByteSize;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Upload configuration section
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct UploadConfig {
     pub max_photos_per_request: usize,
     pub max_photo_size: ByteSize,

--- a/api/src/config/worker_pool.rs
+++ b/api/src/config/worker_pool.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2026 The Photometoria contributors
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Worker pool configuration section.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct WorkerPoolConfig {
     /// Minimum photos to process before allowing model swap.
     #[serde(default = "WorkerPoolConfig::default_min_photos_before_swap")]

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -3,35 +3,75 @@
 
 mod cli;
 
+use std::path::Path;
+
+use clap::Parser;
 use photometoria_rest_api::config::load_config;
 use photometoria_rest_api::routes;
 use photometoria_rest_api::startup::{init_app_state, init_tracing, shutdown_signal};
 
-use cli::parse_args;
+use cli::{Cli, Command, ConfigCommand};
 
 #[tokio::main]
 async fn main() {
-    let args = parse_args();
+    let cli = Cli::parse();
 
+    match cli.command {
+        Some(Command::Config { subcommand }) => match subcommand {
+            ConfigCommand::Check => config_check(&cli.config),
+            ConfigCommand::Show => config_show(&cli.config),
+        },
+        None => run_server(&cli.config).await,
+    }
+}
+
+fn config_check(config_path: &Path) {
+    match load_config(config_path) {
+        Ok(_) => println!("Configuration is valid."),
+        Err(e) => {
+            eprintln!("Error: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn config_show(config_path: &Path) {
+    let config = match load_config(config_path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            std::process::exit(1);
+        }
+    };
+    match toml::to_string(&config) {
+        Ok(output) => print!("{output}"),
+        Err(e) => {
+            eprintln!("Error serializing configuration: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+async fn run_server(config_path: &Path) {
     init_tracing();
 
     tracing::info!("Starting Photometoria REST API...");
 
-    let config = match load_config(&args.config) {
+    let config = match load_config(config_path) {
         Ok(config) => config,
         Err(e) => {
-            tracing::error!("{}", e);
+            tracing::error!("{e}");
             std::process::exit(1);
         }
     };
 
     let addr = config.server_addr();
-    tracing::info!("Server listening on http://{}", addr);
+    tracing::info!("Server listening on http://{addr}");
 
     let state = match init_app_state(config).await {
         Ok(state) => state,
         Err(e) => {
-            tracing::error!("{}", e);
+            tracing::error!("{e}");
             std::process::exit(1);
         }
     };
@@ -40,7 +80,7 @@ async fn main() {
     let listener = match tokio::net::TcpListener::bind(&addr).await {
         Ok(listener) => listener,
         Err(e) => {
-            tracing::error!("Failed to bind to {}: {}", addr, e);
+            tracing::error!("Failed to bind to {addr}: {e}");
             std::process::exit(1);
         }
     };
@@ -49,7 +89,7 @@ async fn main() {
         .with_graceful_shutdown(shutdown_signal())
         .await
     {
-        tracing::error!("Server error: {}", e);
+        tracing::error!("Server error: {e}");
         std::process::exit(1);
     }
 


### PR DESCRIPTION
## Summary

- Replace hand-rolled argument parser with clap derive
- Add `photometoria config check` — validates config file without starting the server, exits 1 on error
- Add `photometoria config show` — prints effective configuration (file + defaults) as valid TOML, reusable as config file
- Add `photometoria --version` — version read from Cargo.toml at compile time
- `photometoria` without arguments retains existing server start behaviour
- Add `serde::Serialize` to all config structs to support TOML serialization

## Test plan

- [ ] `cargo test` passes (390+ tests, 0 failures)
- [ ] `photometoria --help` shows all commands with descriptions
- [ ] `photometoria config --help` shows check and show subcommands
- [ ] `photometoria --version` prints `photometoria 0.3.1`
- [ ] `photometoria config check` exits 0 on valid config, 1 with error on invalid
- [ ] `photometoria config show` outputs valid TOML that can be saved and reloaded
- [ ] `photometoria config show | photometoria config check --config /dev/stdin` round-trips cleanly

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)