### PR TITLE
feat: add server-plugin API version compatibility check

### DIFF
--- a/api/docs/Photometoria.postman_collection.json
+++ b/api/docs/Photometoria.postman_collection.json
@@ -5,7 +5,27 @@
         "description": "Collection for testing Photometoria REST API endpoints",
         "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
     },
+    "event": [
+        {
+            "listen": "prerequest",
+            "script": {
+                "type": "text/javascript",
+                "exec": [
+                    "pm.request.headers.add({",
+                    "    key: 'X-Api-Version',",
+                    "    value: pm.collectionVariables.get('api_version')",
+                    "});"
+                ]
+            }
+        }
+    ],
     "variable": [
+        {
+            "key": "api_version",
+            "value": "0.1",
+            "type": "string",
+            "description": "API version sent in the X-Api-Version request header"
+        },
         {
             "key": "base_url",
             "value": "http://localhost:3000",

--- a/api/docs/api-reference.md
+++ b/api/docs/api-reference.md
@@ -12,6 +12,51 @@ http://localhost:8080/api
 
 (Default port is 8080, configurable in `config.toml`)
 
+## API Version Negotiation
+
+Every request **must** include the following header:
+
+```
+X-Api-Version: <major>.<minor>
+```
+
+The server validates the header on every request and includes it in every successful response.
+
+### Compatibility rules
+
+| Client | Server | Compatible | Reason |
+|--------|--------|------------|--------|
+| 0.1    | 0.1    | ✅ Yes     | Exact match |
+| 0.1    | 0.3    | ✅ Yes     | Same major; server supports 0.1 and later |
+| 0.3    | 0.1    | ❌ No      | Client requires features not present on the server |
+| 1.0    | 0.1    | ❌ No      | Different major: breaking change |
+
+### Versioning errors
+
+**Missing header** — `400 Bad Request`
+
+```json
+{
+  "error": "API_VERSION_MISSING",
+  "message": "The X-Api-Version header is required"
+}
+```
+
+**Incompatible version** — `406 Not Acceptable`
+
+```json
+{
+  "error": "API_VERSION_NOT_SUPPORTED",
+  "message": "Server API version 0.1 is not compatible with client version 1.0"
+}
+```
+
+### Current version
+
+The server currently supports API version **`0.1`**.
+
+---
+
 ## Data Flow
 
 ### Complete Workflow Example

--- a/api/src/api_version.rs
+++ b/api/src/api_version.rs
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 The Photometoria contributors
+
+//! API version negotiation: constant, compatibility check, and request middleware.
+
+use axum::Json;
+use axum::extract::Request;
+use axum::http::{StatusCode, header};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+
+use crate::handlers::app_error::ErrorResponse;
+
+pub const API_VERSION: &str = "1.0";
+pub const HEADER_NAME: &str = "x-api-version";
+
+fn parse_version(s: &str) -> Option<(u32, u32)> {
+    let (major_str, minor_str) = s.split_once('.')?;
+    let major = major_str.parse::<u32>().ok()?;
+    let minor = minor_str.parse::<u32>().ok()?;
+    Some((major, minor))
+}
+
+fn check_compatibility(client: &str, server: &str) -> bool {
+    match (parse_version(client), parse_version(server)) {
+        (Some((cm, cn)), Some((sm, sn))) => cm == sm && sn >= cn,
+        _ => false,
+    }
+}
+
+pub async fn api_version_middleware(req: Request, next: Next) -> Response {
+    let client_version = req
+        .headers()
+        .get(HEADER_NAME)
+        .and_then(|v| v.to_str().ok().map(str::to_owned));
+
+    match client_version {
+        None => (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: "API_VERSION_MISSING".to_string(),
+                message: "The X-Api-Version header is required".to_string(),
+            }),
+        )
+            .into_response(),
+
+        Some(ref version) if !check_compatibility(version, API_VERSION) => (
+            StatusCode::NOT_ACCEPTABLE,
+            Json(ErrorResponse {
+                error: "API_VERSION_NOT_SUPPORTED".to_string(),
+                message: format!(
+                    "Server API version {} is not compatible with client version {}",
+                    API_VERSION, version
+                ),
+            }),
+        )
+            .into_response(),
+
+        Some(_) => {
+            let mut response = next.run(req).await;
+            response.headers_mut().insert(
+                header::HeaderName::from_static(HEADER_NAME),
+                header::HeaderValue::from_static(API_VERSION),
+            );
+            response
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::middleware;
+    use axum::routing::get;
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    fn test_app() -> Router {
+        Router::new()
+            .route("/test", get(|| async { "ok" }))
+            .layer(middleware::from_fn(api_version_middleware))
+    }
+
+    // ── Compatibility logic ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_check_compatible_same_version() {
+        assert!(check_compatibility("1.0", "1.0"));
+    }
+
+    #[test]
+    fn test_check_compatible_server_minor_higher() {
+        assert!(check_compatibility("1.0", "1.3"));
+    }
+
+    #[test]
+    fn test_check_incompatible_client_minor_higher() {
+        assert!(!check_compatibility("1.1", "1.0"));
+        assert!(!check_compatibility("1.99", "1.0"));
+    }
+
+    #[test]
+    fn test_check_incompatible_different_major() {
+        assert!(!check_compatibility("2.0", "1.0"));
+        assert!(!check_compatibility("0.9", "1.0"));
+    }
+
+    #[test]
+    fn test_check_incompatible_malformed_version() {
+        assert!(!check_compatibility("", "1.0"));
+        assert!(!check_compatibility("1", "1.0"));
+        assert!(!check_compatibility("1.0.0", "1.0"));
+        assert!(!check_compatibility("abc", "1.0"));
+        assert!(!check_compatibility("1.abc", "1.0"));
+    }
+
+    // ── Middleware ───────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_middleware_missing_header_returns_400() {
+        let response = test_app()
+            .oneshot(Request::builder().uri("/test").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let error: ErrorResponse = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(error.error, "API_VERSION_MISSING");
+    }
+
+    #[tokio::test]
+    async fn test_middleware_incompatible_major_returns_406() {
+        let response = test_app()
+            .oneshot(
+                Request::builder()
+                    .uri("/test")
+                    .header("X-Api-Version", "2.0")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_ACCEPTABLE);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let error: ErrorResponse = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(error.error, "API_VERSION_NOT_SUPPORTED");
+    }
+
+    #[tokio::test]
+    async fn test_middleware_client_minor_higher_returns_406() {
+        let response = test_app()
+            .oneshot(
+                Request::builder()
+                    .uri("/test")
+                    .header("X-Api-Version", "1.1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_ACCEPTABLE);
+    }
+
+    #[tokio::test]
+    async fn test_middleware_compatible_version_passes_through() {
+        let response = test_app()
+            .oneshot(
+                Request::builder()
+                    .uri("/test")
+                    .header("X-Api-Version", API_VERSION)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_middleware_compatible_version_adds_response_header() {
+        let response = test_app()
+            .oneshot(
+                Request::builder()
+                    .uri("/test")
+                    .header("X-Api-Version", API_VERSION)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let version_header = response.headers().get("x-api-version");
+        assert!(version_header.is_some());
+        assert_eq!(version_header.unwrap().to_str().unwrap(), API_VERSION);
+    }
+}

--- a/api/src/api_version.rs
+++ b/api/src/api_version.rs
@@ -11,7 +11,7 @@ use axum::response::{IntoResponse, Response};
 
 use crate::handlers::app_error::ErrorResponse;
 
-pub const API_VERSION: &str = "1.0";
+pub const API_VERSION: &str = "0.1";
 pub const HEADER_NAME: &str = "x-api-version";
 
 fn parse_version(s: &str) -> Option<(u32, u32)> {

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -6,6 +6,7 @@
 //! This module exposes the core components of the Photometoria API
 //! for use in integration tests and as a library.
 
+pub mod api_version;
 pub mod app_state;
 pub mod config;
 pub mod handlers;

--- a/api/src/routes/mod.rs
+++ b/api/src/routes/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2026 The Photometoria contributors
 
+use crate::api_version::{API_VERSION, api_version_middleware};
 use crate::app_state::AppState;
 use crate::handlers::catalogs::list_catalogs;
 use crate::handlers::info::info;
@@ -15,6 +16,7 @@ use crate::handlers::upload_photos::upload_photos;
 use axum::{
     Router,
     extract::DefaultBodyLimit,
+    middleware,
     routing::{get, post},
 };
 use tower_http::trace::TraceLayer;
@@ -57,6 +59,7 @@ pub fn create_router(state: AppState) -> Router {
         .route("/api/jobs/{job_id}/results", get(get_job_results))
         .route("/api/jobs/{job_id}/cancel", post(cancel_job))
         .route("/api/jobs/{job_id}/retry", post(retry_job))
+        .layer(middleware::from_fn(api_version_middleware))
         .layer(TraceLayer::new_for_http())
         .with_state(state)
 }
@@ -81,6 +84,7 @@ mod tests {
                 Request::builder()
                     .method("GET")
                     .uri("/api/tasks/not-a-uuid")
+                    .header("X-Api-Version", API_VERSION)
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/plugin/photometoria.lrdevplugin/PluginInfoProvider.lua
+++ b/plugin/photometoria.lrdevplugin/PluginInfoProvider.lua
@@ -175,10 +175,15 @@ local function sectionsForTopOfDialog(f, propertyTable)
 				end
 				suppressHostObserver = false
 			else
-				local unreachableStr = LOC "$$$/Photometoria/Status/Unreachable=Unreachable"
-				propertyTable.statusText = unreachableStr
+				local statusStr
+				if data.versionMismatch then
+					statusStr = LOC "$$$/Photometoria/Status/Incompatible=Incompatible"
+				else
+					statusStr = LOC "$$$/Photometoria/Status/Unreachable=Unreachable"
+				end
+				propertyTable.statusText = statusStr
 				propertyTable.statusMessage = data.message
-				propertyTable.synopsis = unreachableStr
+				propertyTable.synopsis = statusStr
 			end
 
 			if ServerConnection.isValidHostPort(RecentHosts.extractHost(propertyTable.serverHost)) then

--- a/plugin/photometoria.lrdevplugin/ServerConnection.lua
+++ b/plugin/photometoria.lrdevplugin/ServerConnection.lua
@@ -11,6 +11,20 @@ local ServerConnection = {}
 local TIMEOUT_SECONDS = 10
 local UPLOAD_TIMEOUT_SECONDS = 120
 
+local PLUGIN_API_VERSION = "0.1"
+local VERSION_HEADER = { field = 'X-Api-Version', value = PLUGIN_API_VERSION }
+
+--- Returns the value of a response header by name (case-insensitive), or nil if absent.
+local function findHeader(headers, name)
+	local nameLower = name:lower()
+	for _, h in ipairs(headers) do
+		if h.field and h.field:lower() == nameLower then
+			return h.value
+		end
+	end
+	return nil
+end
+
 --- Returns the base API path for catalog-scoped endpoints.
 local function catalogBasePath(catalogId)
 	return '/api/catalogs/' .. catalogId
@@ -70,7 +84,7 @@ end
 function ServerConnection.info(host)
 	local url = 'http://' .. host .. '/api/info'
 
-	local body, headers = LrHttp.get(url, nil, TIMEOUT_SECONDS)
+	local body, headers = LrHttp.get(url, { VERSION_HEADER }, TIMEOUT_SECONDS)
 
 	if not body or not headers then
 		return false, {
@@ -78,9 +92,23 @@ function ServerConnection.info(host)
 		}
 	end
 
+	if headers.status == 406 then
+		return false, {
+			message = LOC("$$$/Photometoria/Status/VersionMismatch=Server API version is not compatible with this plugin. Required: ^1.", PLUGIN_API_VERSION),
+			versionMismatch = true,
+		}
+	end
+
 	if headers.status ~= 200 then
 		return false, {
 			message = LOC("$$$/Photometoria/Status/ServerError=Server responded with status ^1", tostring(headers.status)),
+		}
+	end
+
+	if not findHeader(headers, "x-api-version") then
+		return false, {
+			message = LOC("$$$/Photometoria/Status/VersionMismatch=Server API version is not compatible with this plugin. Required: ^1.", PLUGIN_API_VERSION),
+			versionMismatch = true,
 		}
 	end
 
@@ -128,6 +156,7 @@ function ServerConnection.createTask(host, catalogId, name, context)
 
 	local headers = {
 		{ field = 'Content-Type', value = 'application/json' },
+		VERSION_HEADER,
 	}
 
 	local respBody, respHeaders = LrHttp.post(url, body, headers, 'POST', TIMEOUT_SECONDS)
@@ -160,7 +189,7 @@ end
 local function getJson(host, path)
 	local url = 'http://' .. host .. path
 
-	local body, headers = LrHttp.get(url, nil, TIMEOUT_SECONDS)
+	local body, headers = LrHttp.get(url, { VERSION_HEADER }, TIMEOUT_SECONDS)
 
 	if not body or not headers then
 		return false, {
@@ -168,9 +197,23 @@ local function getJson(host, path)
 		}
 	end
 
+	if headers.status == 406 then
+		return false, {
+			message = LOC("$$$/Photometoria/Status/VersionMismatch=Server API version is not compatible with this plugin. Required: ^1.", PLUGIN_API_VERSION),
+			versionMismatch = true,
+		}
+	end
+
 	if headers.status ~= 200 then
 		return false, {
 			message = LOC("$$$/Photometoria/Status/ServerError=Server responded with status ^1", tostring(headers.status)),
+		}
+	end
+
+	if not findHeader(headers, "x-api-version") then
+		return false, {
+			message = LOC("$$$/Photometoria/Status/VersionMismatch=Server API version is not compatible with this plugin. Required: ^1.", PLUGIN_API_VERSION),
+			versionMismatch = true,
 		}
 	end
 
@@ -235,6 +278,7 @@ function ServerConnection.createJob(host, taskId, provider, model, language, pho
 
 	local headers = {
 		{ field = 'Content-Type', value = 'application/json' },
+		VERSION_HEADER,
 	}
 
 	local respBody, respHeaders = LrHttp.post(url, body, headers, 'POST', TIMEOUT_SECONDS)
@@ -275,6 +319,7 @@ function ServerConnection.deleteTask(host, taskId)
 
 	local headers = {
 		{ field = 'Content-Type', value = 'application/json' },
+		VERSION_HEADER,
 	}
 
 	local respBody, respHeaders = LrHttp.post(url, '', headers, 'DELETE', TIMEOUT_SECONDS)
@@ -308,6 +353,7 @@ function ServerConnection.retryJob(host, jobId)
 
 	local headers = {
 		{ field = 'Content-Type', value = 'application/json' },
+		VERSION_HEADER,
 	}
 
 	local respBody, respHeaders = LrHttp.post(url, '', headers, 'POST', TIMEOUT_SECONDS)
@@ -348,6 +394,7 @@ function ServerConnection.cancelJob(host, jobId)
 
 	local headers = {
 		{ field = 'Content-Type', value = 'application/json' },
+		VERSION_HEADER,
 	}
 
 	local respBody, respHeaders = LrHttp.post(url, '', headers, 'POST', TIMEOUT_SECONDS)
@@ -381,6 +428,7 @@ function ServerConnection.deleteJob(host, jobId)
 
 	local headers = {
 		{ field = 'Content-Type', value = 'application/json' },
+		VERSION_HEADER,
 	}
 
 	local respBody, respHeaders = LrHttp.post(url, '', headers, 'DELETE', TIMEOUT_SECONDS)
@@ -430,7 +478,7 @@ function ServerConnection.uploadPhotos(host, taskId, files)
 		}
 	end
 
-	local respBody, respHeaders = LrHttp.postMultipart(url, content, nil, UPLOAD_TIMEOUT_SECONDS)
+	local respBody, respHeaders = LrHttp.postMultipart(url, content, { VERSION_HEADER }, UPLOAD_TIMEOUT_SECONDS)
 
 	if not respBody or not respHeaders then
 		return false, {
@@ -458,6 +506,7 @@ function ServerConnection.updateTask(host, taskId, name, context)
 
 	local headers = {
 		{ field = 'Content-Type', value = 'application/json' },
+		VERSION_HEADER,
 	}
 
 	local respBody, respHeaders = LrHttp.post(url, body, headers, 'PATCH', TIMEOUT_SECONDS)
@@ -506,6 +555,7 @@ function ServerConnection.deletePhoto(host, photoId)
 
 	local headers = {
 		{ field = 'Content-Type', value = 'application/json' },
+		VERSION_HEADER,
 	}
 
 	local respBody, respHeaders = LrHttp.post(url, '', headers, 'DELETE', TIMEOUT_SECONDS)

--- a/plugin/photometoria.lrdevplugin/TranslatedStrings_it.txt
+++ b/plugin/photometoria.lrdevplugin/TranslatedStrings_it.txt
@@ -9,6 +9,8 @@
 "$$$/Photometoria/Status/Connecting=Connessione..."
 "$$$/Photometoria/Status/Online=Online"
 "$$$/Photometoria/Status/Unreachable=Non raggiungibile"
+"$$$/Photometoria/Status/Incompatible=Incompatibile"
+"$$$/Photometoria/Status/VersionMismatch=Versione API del server non compatibile con il plugin. Versione richiesta: ^1."
 "$$$/Photometoria/Status/ConnectedTo=Connesso a ^1"
 "$$$/Photometoria/Status/CannotReach=Impossibile raggiungere il server ^1"
 "$$$/Photometoria/Status/ServerError=Il server ha risposto con stato ^1"


### PR DESCRIPTION
## Summary

- Introduces `X-Api-Version` header negotiation on every API request: the server returns `400` if the header is missing and `406` if the version is incompatible
- The plugin injects `X-Api-Version: 0.1` in every `LrHttp` call and shows "Incompatibile" (instead of the generic "Non raggiungibile") when the server is incompatible or too old to support version negotiation
- Documents the versioning protocol in `api-reference.md` and wires the Postman collection with a pre-request script

## Test plan

- [x] `cargo test` — 394 tests pass, including 10 new tests for `check_compatibility` and the Axum middleware
- [ ] Connect the plugin to a compatible server (0.1) → status "Online"
- [ ] Connect the plugin to an old server without `X-Api-Version` support → status "Incompatibile"
- [ ] Connect the plugin to a server with a different major version → status "Incompatibile"
- [ ] Verify Postman: import collection and confirm `X-Api-Version: 0.1` is sent automatically on every request

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)