### PR TITLE
feat(api): add config get subcommand and /health liveness endpoint

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -3,6 +3,7 @@
 ## API Workflow
 
 ```
+0. GET  /health                            → Liveness probe (no version header)
 1. GET  /api/info                          → Server info and capabilities
 1b. GET /api/catalogs                      → List all catalogs with task counts
 2. GET  /api/providers                     → List configured AI providers

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -25,9 +25,9 @@
 
 ```
 api/src/
-├── main.rs           # Entry point, subcommand dispatch (server / config check / config show)
+├── main.rs           # Entry point, subcommand dispatch (server / config check / config show / config get)
 ├── lib.rs            # Library crate root (re-exports)
-├── cli.rs            # CLI definition (clap derive): --config, config check, config show, --version
+├── cli.rs            # CLI definition (clap derive): --config, config check, config show, config get, --version
 ├── startup.rs        # Server initialization and startup logic
 ├── app_state.rs      # Shared application state (AppState)
 ├── config/           # TOML configuration parsing

--- a/api/docs/Photometoria.postman_collection.json
+++ b/api/docs/Photometoria.postman_collection.json
@@ -55,6 +55,56 @@
     ],
     "item": [
         {
+            "name": "Health",
+            "item": [
+                {
+                    "name": "Health Check",
+                    "request": {
+                        "method": "GET",
+                        "header": [],
+                        "url": {
+                            "raw": "{{base_url}}/health",
+                            "host": [
+                                "{{base_url}}"
+                            ],
+                            "path": [
+                                "health"
+                            ]
+                        },
+                        "description": "Liveness probe. Returns 200 OK while the server is accepting requests. Exempt from API version negotiation (no X-Api-Version header required)."
+                    },
+                    "response": [
+                        {
+                            "name": "Success",
+                            "originalRequest": {
+                                "method": "GET",
+                                "header": [],
+                                "url": {
+                                    "raw": "{{base_url}}/health",
+                                    "host": [
+                                        "{{base_url}}"
+                                    ],
+                                    "path": [
+                                        "health"
+                                    ]
+                                }
+                            },
+                            "status": "OK",
+                            "code": 200,
+                            "_postman_previewlanguage": "json",
+                            "header": [
+                                {
+                                    "key": "Content-Type",
+                                    "value": "application/json"
+                                }
+                            ],
+                            "body": "{\n    \"status\": \"ok\"\n}"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "name": "Server Info",
             "item": [
                 {

--- a/api/docs/api-reference.md
+++ b/api/docs/api-reference.md
@@ -22,6 +22,8 @@ X-Api-Version: <major>.<minor>
 
 The server validates the header on every request and includes it in every successful response.
 
+The only exception is `GET /health` (liveness probe), which is exempt from version negotiation so monitoring tools and the install script can check service health without negotiating a version.
+
 ### Compatibility rules
 
 | Client | Server | Compatible | Reason |
@@ -115,6 +117,19 @@ This example demonstrates a typical workflow from task creation to cleanup:
 ```
 
 ## System Endpoints
+
+### GET /health
+
+Liveness probe. Returns `200 OK` as long as the server process is accepting requests.
+This endpoint is **exempt from API version negotiation** — no `X-Api-Version` header is required.
+
+**Response:** `200 OK`
+
+```json
+{
+  "status": "ok"
+}
+```
 
 ### GET /api/info
 

--- a/api/docs/development.md
+++ b/api/docs/development.md
@@ -333,6 +333,13 @@ api/tests/
 
 All endpoints can be tested using curl. Below are examples for common workflows.
 
+**Health check** (liveness probe, no `X-Api-Version` header required):
+
+```bash
+curl http://localhost:3000/health
+# → {"status":"ok"}
+```
+
 **0. List all catalogs:**
 
 ```bash

--- a/api/src/cli.rs
+++ b/api/src/cli.rs
@@ -31,4 +31,9 @@ pub enum ConfigCommand {
     Check,
     /// Print the effective configuration as valid TOML
     Show,
+    /// Print the value of a single configuration key
+    Get {
+        /// Dotted key path (e.g. server.port, storage.path)
+        key: String,
+    },
 }

--- a/api/src/config/mod.rs
+++ b/api/src/config/mod.rs
@@ -39,6 +39,38 @@ pub struct Config {
 }
 
 impl Config {
+    /// Returns the string representation of a single config value identified by a dotted key.
+    ///
+    /// Only scalar values (string, integer, float, boolean) can be retrieved.
+    /// Returns an error if the key is not found or refers to a table or array.
+    pub fn get_value(&self, key: &str) -> anyhow::Result<String> {
+        use anyhow::Context;
+
+        let value = toml::Value::try_from(self).context("Failed to serialize configuration")?;
+
+        let mut current = &value;
+        for segment in key.split('.') {
+            match current {
+                toml::Value::Table(table) => {
+                    current = table
+                        .get(segment)
+                        .with_context(|| format!("Key '{key}' not found in configuration"))?;
+                }
+                _ => anyhow::bail!("Key '{key}' not found in configuration"),
+            }
+        }
+
+        let output = match current {
+            toml::Value::String(s) => s.clone(),
+            toml::Value::Integer(i) => i.to_string(),
+            toml::Value::Float(f) => f.to_string(),
+            toml::Value::Boolean(b) => b.to_string(),
+            _ => anyhow::bail!("Key '{key}' refers to a table or array, not a scalar value"),
+        };
+
+        Ok(output)
+    }
+
     /// Returns the server address as a string suitable for binding.
     pub fn server_addr(&self) -> String {
         format!("{}:{}", self.server.host, self.server.port)
@@ -141,5 +173,37 @@ mod tests {
     fn test_log_summary_does_not_panic() {
         let config = Config::default();
         config.log_summary();
+    }
+
+    #[test]
+    fn test_get_value_server_port() {
+        let config = Config::default();
+        let port = config.get_value("server.port").unwrap();
+        assert_eq!(port, config.server.port.to_string());
+    }
+
+    #[test]
+    fn test_get_value_storage_path() {
+        let config = Config::default();
+        let path = config.get_value("storage.path").unwrap();
+        assert_eq!(path, config.storage.path);
+    }
+
+    #[test]
+    fn test_get_value_not_found() {
+        let config = Config::default();
+        assert!(config.get_value("nonexistent.key").is_err());
+    }
+
+    #[test]
+    fn test_get_value_partial_key_not_found() {
+        let config = Config::default();
+        assert!(config.get_value("server.nonexistent").is_err());
+    }
+
+    #[test]
+    fn test_get_value_table_returns_error() {
+        let config = Config::default();
+        assert!(config.get_value("server").is_err());
     }
 }

--- a/api/src/handlers/health.rs
+++ b/api/src/handlers/health.rs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 The Photometoria contributors
+
+use axum::Json;
+use serde_json::{Value, json};
+
+/// Liveness probe. Returns 200 with a minimal body.
+///
+/// Registered outside the API version middleware so monitoring tools and the
+/// install script can check service health without negotiating an API version.
+pub async fn health() -> Json<Value> {
+    Json(json!({ "status": "ok" }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_health_returns_ok() {
+        let Json(body) = health().await;
+        assert_eq!(body["status"], "ok");
+    }
+}

--- a/api/src/handlers/mod.rs
+++ b/api/src/handlers/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod app_error;
 pub mod catalogs;
+pub mod health;
 pub mod jobs;
 pub mod photos;
 pub mod providers;

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -20,6 +20,7 @@ async fn main() {
         Some(Command::Config { subcommand }) => match subcommand {
             ConfigCommand::Check => config_check(&cli.config),
             ConfigCommand::Show => config_show(&cli.config),
+            ConfigCommand::Get { key } => config_get(&cli.config, &key),
         },
         None => run_server(&cli.config).await,
     }
@@ -28,6 +29,23 @@ async fn main() {
 fn config_check(config_path: &Path) {
     match load_config(config_path) {
         Ok(_) => println!("Configuration is valid."),
+        Err(e) => {
+            eprintln!("Error: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn config_get(config_path: &Path, key: &str) {
+    let config = match load_config(config_path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            std::process::exit(1);
+        }
+    };
+    match config.get_value(key) {
+        Ok(value) => print!("{value}"),
         Err(e) => {
             eprintln!("Error: {e}");
             std::process::exit(1);

--- a/api/src/routes/mod.rs
+++ b/api/src/routes/mod.rs
@@ -4,6 +4,7 @@
 use crate::api_version::{API_VERSION, api_version_middleware};
 use crate::app_state::AppState;
 use crate::handlers::catalogs::list_catalogs;
+use crate::handlers::health::health;
 use crate::handlers::info::info;
 use crate::handlers::jobs::{
     cancel_job, create_job, delete_job, get_job, get_job_results, list_jobs, list_task_jobs,
@@ -60,6 +61,9 @@ pub fn create_router(state: AppState) -> Router {
         .route("/api/jobs/{job_id}/cancel", post(cancel_job))
         .route("/api/jobs/{job_id}/retry", post(retry_job))
         .layer(middleware::from_fn(api_version_middleware))
+        // Registered after the version middleware: liveness probe is exempt from
+        // API version negotiation.
+        .route("/health", get(health))
         .layer(TraceLayer::new_for_http())
         .with_state(state)
 }
@@ -97,5 +101,24 @@ mod tests {
         let error: ErrorResponse = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(error.error, "invalid_uuid");
         assert_eq!(error.message, "Invalid UUID format in path parameter");
+    }
+
+    #[tokio::test]
+    async fn test_health_exempt_from_version_middleware() {
+        let ts = create_test_state().await;
+        let app = create_router(ts.state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
     }
 }

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -53,31 +53,20 @@ parse_flags() {
 }
 
 # ---------------------------------------------------------------------------
-# Config parsing (requires Python 3.11+)
+# Config parsing (via photometoria binary)
 # ---------------------------------------------------------------------------
-
-check_python() {
-    python3 -c "import tomllib" 2>/dev/null && return
-    error "Python 3.11+ is required to parse config.toml (tomllib not found)"
-    exit 1
-}
 
 read_config_values() {
     local config_file="$1"
+    local binary="${INSTALL_DIR}/${BINARY_NAME}"
     [[ -f "${config_file}" ]] || return
+    [[ -f "${binary}" ]] || return
 
-    local result
-    result="$(python3 - "${config_file}" <<'PYEOF'
-import tomllib, sys
-with open(sys.argv[1], 'rb') as f:
-    c = tomllib.load(f)
-print(c.get('server', {}).get('port', 8080))
-print(c.get('storage', {}).get('path', '/var/photometoria/storage'))
-PYEOF
-)" || return
-
-    API_PORT="$(echo "${result}" | sed -n '1p')"
-    STORAGE_DIR="$(echo "${result}" | sed -n '2p')"
+    local port path
+    port="$("${binary}" config get server.port --config "${config_file}" 2>/dev/null)" \
+        && API_PORT="${port}" || true
+    path="$("${binary}" config get storage.path --config "${config_file}" 2>/dev/null)" \
+        && STORAGE_DIR="${path}" || true
 }
 
 # ---------------------------------------------------------------------------
@@ -202,13 +191,21 @@ install_config() {
     local config_file="${CONFIG_DIR}/config.toml"
 
     if [[ -n "${CONFIG_SOURCE}" ]]; then
+        if [[ -f "${config_file}" ]]; then
+            echo -n "Config already exists at '${config_file}'. Replace with '${CONFIG_SOURCE}'? [y/N] "
+            read -r confirm
+            if [[ "${confirm,,}" != "y" ]]; then
+                info "Keeping existing config at '${config_file}'"
+                return
+            fi
+        fi
         install -m 640 -o root -g "${SERVICE_USER}" "${CONFIG_SOURCE}" "${config_file}"
         info "Config copied from '${CONFIG_SOURCE}' to '${config_file}'"
         return
     fi
 
     if [[ -f "${config_file}" ]]; then
-        info "Config already exists at ${config_file} — not overwriting"
+        info "Config already exists at '${config_file}' — not overwriting"
         return
     fi
 
@@ -263,26 +260,28 @@ cmd_install() {
     [[ -f "${binary}" ]]  || { error "Binary not found: ${binary}"; exit 1; }
 
     require_root
-    check_python
 
     # Fatal checks — run before touching anything
     check_config_source
-    [[ -n "${CONFIG_SOURCE}" ]] && read_config_values "${CONFIG_SOURCE}"
     check_service_name
     check_ollama
 
-    # Warn-and-continue checks
+    info "Installing Photometoria..."
+    create_system_user
+    prepare_dir "${INSTALL_DIR}"  "root:root" "755" "Install directory"
+    prepare_dir "${CONFIG_DIR}"   "root:root" "755" "Config directory"
+    prepare_dir "${BACKUP_DIR}"   "root:root" "755" "Backup directory"
+    install_binary "${binary}"
+    install_config
+
+    # Read effective values from the installed config (binary + config now in place)
+    read_config_values "${CONFIG_DIR}/config.toml"
+
+    # Warn-and-continue checks (STORAGE_DIR now reflects the installed config)
     check_storage_dir
     check_dir_writable "${BACKUP_DIR}" "Backup directory"
 
-    info "Installing Photometoria..."
-    create_system_user
-    prepare_dir "${INSTALL_DIR}"  "root:root"                    "755" "Install directory"
-    prepare_dir "${CONFIG_DIR}"   "root:root"                    "755" "Config directory"
     prepare_dir "${STORAGE_DIR}"  "${SERVICE_USER}:${SERVICE_USER}" "750" "Storage directory"
-    prepare_dir "${BACKUP_DIR}"   "root:root"                    "755" "Backup directory"
-    install_binary "${binary}"
-    install_config
     install_service
     systemctl start "${SERVICE_NAME}"
     health_check || true
@@ -304,7 +303,6 @@ cmd_update() {
     [[ -f "${binary}" ]]  || { error "Binary not found: ${binary}"; exit 1; }
 
     require_root
-    check_python
     info "Updating Photometoria..."
 
     systemctl stop "${SERVICE_NAME}" || true
@@ -426,8 +424,7 @@ Options (applicable to all commands):
   --install-dir  <dir>   Directory where the binary is placed   (default: /usr/local/bin)
   --backup-dir   <dir>   Binary backup directory for updates    (default: /var/backups/photometoria)
 
-Storage directory and API port are read from config.toml (keys: storage.path, server.port).
-Requires Python 3.11+ (tomllib). See issue #135 for a planned native alternative.
+Storage directory and API port are read from config.toml via 'photometoria config get'.
 
 Environment variables (lowest precedence, overridden by flags):
   PHOTOMETORIA_CONFIG, PHOTOMETORIA_SERVICE_USER, PHOTOMETORIA_SERVICE_NAME,

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -235,7 +235,7 @@ install_service() {
 
 health_check() {
     read_config_values "${CONFIG_DIR}/config.toml"
-    local url="http://localhost:${API_PORT}/api/info"
+    local url="http://localhost:${API_PORT}/health"
     info "Waiting for service to become healthy..."
     local attempt=0
     while [[ "${attempt}" -lt "${HEALTH_CHECK_ATTEMPTS}" ]]; do
@@ -389,10 +389,10 @@ cmd_status() {
     echo ""
     echo "=== API Health ==="
     read_config_values "${CONFIG_DIR}/config.toml"
-    if curl -sf "http://localhost:${API_PORT}/api/info"; then
+    if curl -sf "http://localhost:${API_PORT}/health"; then
         echo ""
     else
-        echo "API not reachable at http://localhost:${API_PORT}/api/info"
+        echo "API not reachable at http://localhost:${API_PORT}/health"
     fi
 
     if [[ -f "${INSTALL_DIR}/${BINARY_NAME}" ]]; then


### PR DESCRIPTION
## Summary

- Adds `photometoria config get <dotted.key>` subcommand to print a single config value to stdout, reusing the TOML parser already compiled into the binary
- Removes the implicit Python 3.11+ runtime dependency from `scripts/install-linux.sh`: storage path and API port are now read via `photometoria config get` instead of `python3 -c "import tomllib ..."`
- Reorders `cmd_install` so effective values are always read from the **installed** config (after binary + config are in place), preventing stale values when reinstalling with a different source config
- Adds an interactive prompt before overwriting an existing `config.toml` when `--config SOURCE` is specified
- Adds `GET /health` liveness endpoint, registered **after** the API version middleware layer so it is exempt from version negotiation — fixes the installer's health check and `--status` command, which were receiving `400 API_VERSION_MISSING` after the middleware was added in PR #140
- `/api/info` remains version-gated (consumed by the plugin)

## Test plan

- [ ] `cargo test` — 407 tests pass
- [ ] `photometoria config get server.port --config <file>` prints the port and exits 0
- [ ] `photometoria config get nonexistent.key` exits non-zero with error message
- [ ] `GET /health` returns `200 {"status":"ok"}` without `X-Api-Version` header
- [ ] `GET /api/info` still returns `400 API_VERSION_MISSING` without `X-Api-Version` header
- [ ] `sudo ./scripts/install-linux.sh install <binary> --config <file>` completes with health check passing

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)